### PR TITLE
Dev 20200402 storage certif keycloak

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -19,6 +19,8 @@ AUTH_REQUIRED_SCOPE=''
 REALM_RSA_TYPE=RS256
 # scopes filtered for this Firecrest, eg  firecrest-tds.cscs.ch, firecrest-production.cscs.ch
 FIRECREST_SERVICE='firecrest.some.place'
+# AUTHENTICATION ROLE for FirecREST Service Accounts
+AUTH_ROLE=''
 #-------
 # microservices IPs, also defined on each 'env_make' inside containers
 CERTIFICATOR_IP=192.168.220.11

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       S3_URL: http://192.168.220.19:9000
       S3_ACCESS_KEY: storage_access_key
       S3_SECRET_KEY: storage_secret_key
+      STORAGE_POLLING_INTERVAL: 60 
+      CERT_CIPHER_KEY: 'Df6UZuoPoJ2u5yRwxNfFQ46Nwy8eW1OGTcuhlqn4ONo='
       #debug: "True"
     networks:
       firecrest-internal:

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - "minio"
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
+      # custom host file
+      - "./environment/hosts:/etc/hosts:ro"
 
   tasks:
     build: 

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -79,14 +79,15 @@ services:
       - "2223:22"
 
   minio:
+    # runs on private network so "cluster" can reach it
+    container_name: minio_test_build
     image: minio/minio
     command: minio server /data
-    #ports:
-    #  - "9000:9000"
     environment:
       MINIO_ACCESS_KEY: storage_access_key
       MINIO_SECRET_KEY: storage_secret_key
-    network_mode: "host"
+    ports:
+      - "9000:9000"
 
   taskpersistence:
     image: redis:latest

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -19,6 +19,8 @@ AUTH_REQUIRED_SCOPE=''
 REALM_RSA_TYPE=RS256
 # scopes filtered for this Firecrest, eg  firecrest-tds.cscs.ch, firecrest-production.cscs.ch
 FIRECREST_SERVICE=''
+# AUTHENTICATION ROLE for FirecREST Service Accounts
+AUTH_ROLE=''
 #-------
 # microservices IPs, also defined on each 'env_make' inside containers
 CERTIFICATOR_IP=127.0.0.1

--- a/deploy/test-build/environment/hosts
+++ b/deploy/test-build/environment/hosts
@@ -1,0 +1,6 @@
+::1     ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+127.0.0.1 minio_test_build

--- a/deploy/test-build/environment/storage.env
+++ b/deploy/test-build/environment/storage.env
@@ -28,3 +28,8 @@ XFER_PARTITION=xfer
 # external transfers machine (PUBLIC: name, INTERNAL=url or IP internal)
 EXT_TRANSFER_MACHINE_PUBLIC='cluster'
 EXT_TRANSFER_MACHINE_INTERNAL=127.0.0.1:2223
+
+# Storage polling interval for uploads in seconds
+STORAGE_POLLING_INTERVAL=60 
+# Cipher key to encrypt/decrypt certificates
+CERT_CIPHER_KEY='Df6UZuoPoJ2u5yRwxNfFQ46Nwy8eW1OGTcuhlqn4ONo='

--- a/deploy/test-build/environment/storage.env
+++ b/deploy/test-build/environment/storage.env
@@ -9,7 +9,8 @@ SWIFT_PASS=
 SECRET_KEY=
 
 # for S3
-S3_URL=http://127.0.0.1:9000
+#S3_URL=http://127.0.0.1:9000
+S3_URL=minio_test_build:9000
 S3_ACCESS_KEY=storage_access_key
 S3_SECRET_KEY=storage_secret_key
 

--- a/deploy/test-build/environment/storage.env
+++ b/deploy/test-build/environment/storage.env
@@ -10,7 +10,7 @@ SECRET_KEY=
 
 # for S3
 #S3_URL=http://127.0.0.1:9000
-S3_URL=minio_test_build:9000
+S3_URL=http://minio_test_build:9000
 S3_ACCESS_KEY=storage_access_key
 S3_SECRET_KEY=storage_secret_key
 

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -48,7 +48,6 @@ def check_header(header):
         else:
             if AUTH_AUDIENCE == '':
                 decoded = jwt.decode(header[7:], realm_pubkey, algorithms=realm_pubkey_type, options={'verify_aud': False})
-                logging.info(decoded)
             else:
                 decoded = jwt.decode(header[7:], realm_pubkey, algorithms=realm_pubkey_type, audience=AUTH_AUDIENCE)
 
@@ -169,8 +168,6 @@ def create_certificates(auth_header, cluster, command=None, options=None, exp_ti
     try:
         #jcert = json.loads(urlopen(req).read())
         resp = requests.get(reqURL,headers={AUTH_HEADER_NAME: auth_header})
-        
-        logging.info(resp.text)
         
         jcert = resp.json()
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -181,7 +181,9 @@ def os_to_fs(task_id):
 
             # delete temp object from SWIFT
             # delete_object(username,sourcePath,hash_id)
-            staging.delete_object(containername=username,prefix=task_id,objectname=objectname)
+            
+            # must be deleted after object is moved to storage
+            # staging.delete_object(containername=username,prefix=task_id,objectname=objectname)
 
                         
         # if error, should be prepared for try again

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -55,7 +55,7 @@ def init_queue():
 
     # dictionary: [task_id] = {hash_id,status_code,user,data}
     task_list = persistence.get_all_tasks(r)
-
+    
     # key = task_id ; values = {status_code,user,data}
     for id, value in task_list.items():
         # task_list has id with format task_id, ie: task_2
@@ -70,7 +70,7 @@ def init_queue():
         t.set_status(status,data)
         tasks[t.hash_id] = t
 
-
+    
 @app.route("/",methods=["GET"])
 def list_tasks():
     # checks if AUTH_HEADER_NAME is set
@@ -225,13 +225,15 @@ def update_task(id):
 
         status = request.form["status"]
 
-
-    # if status is not download from SWIFT failed (ST_DWN_ERR) or finished (ST_DWN_END)
-    # or if upload from filesystem to SWIFT failed (ST_UPL_ERR) or finished (ST_UPL_END)
-    # then check of header is needed. ***
+    # All tasks that doesn't need direct user intervention such as:
+    # if status is download from Object Storage (OS) failed (ST_DWN_ERR) or finished (ST_DWN_END)
+    # or if upload from filesystem to OS failed (ST_UPL_ERR) or finished (ST_UPL_END)
+    # or if upload to OS is finished (ST_UPL_CFM) and download to filesystem started (ST_DWN_BEG)
+    # then check of header is NOT needed. ***
     # owner_needed is True if is not ***
     owner_needed = False
-    if status not in [async_task.ST_DWN_END , async_task.ST_DWN_ERR, async_task.ST_UPL_ERR, async_task.ST_UPL_END] :
+    if status not in [async_task.ST_DWN_END , async_task.ST_DWN_ERR, async_task.ST_UPL_ERR, async_task.ST_UPL_END, 
+                        async_task.ST_UPL_CFM, async_task.ST_DWN_BEG,async_task.ST_DWN_END] :
 
 
         #introduced in order to download from SWIFT to

--- a/src/tests/automated_tests/demo.ini
+++ b/src/tests/automated_tests/demo.ini
@@ -2,5 +2,5 @@
 # demo-client
 env_override_existing_values = 1
 env_files =
-    demo.env
     ../../../deploy/demo/common/common.env
+    demo.env

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -89,13 +89,17 @@ def test_post_upload_request(headers):
     print(resp.content)
     assert resp.status_code == 200 or resp.status_code == 204 #TODO: check 204 is right
 
-    # inform upload finished
-    headers.update({"X-Task-ID": task_id})
-    r = requests.put(STORAGE_URL + "/xfer-external/upload", headers=headers)
-    print(r.content)
-    
-    assert r.status_code == 200
+    # download from OS to FS is automatic
+    download_ok = False
+    for i in range(10):
+        r = requests.get(TASK_URL +"/"+task_id, headers=headers)
+        assert r.status_code == 200
+        if r.json()["msg"]["status"] == 114: # import async_tasks -> async_tasks.ST_DWN_END
+	    download_ok = True
+            break
+        sleep(10)
 
+    assert download_ok
 
 
 

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -40,22 +40,23 @@ def test_post_upload_request(headers):
     # request upload form
     data = { "sourcePath": "testsbatch.sh", "targetPath": "/home/testuser" }
     resp = requests.post(STORAGE_URL + "/xfer-external/upload", headers=headers, data=data)
-    print(resp.content)
     assert resp.status_code == 200
 
     task_id = resp.json()["task_id"]
 
     # wait to make sure upload form is ready
-    time.sleep(2)
+    time.sleep(5)
 
     # get upload form from checking task status
     resp = get_task(task_id, headers)
-    print(resp.content)
     assert int(resp.json()["task"]["status"]) == 111 # if form upload ready
 
     # upload file to storage server
     msg = resp.json()["task"]["data"]["msg"]
     url = msg["url"]
+
+
+    url = url.replace("minio_test_build", "127.0.0.1")
 
     resp = None
     
@@ -85,22 +86,20 @@ def test_post_upload_request(headers):
         
         with open(data["sourcePath"], 'rb') as data:
             resp= requests.put(url, data=data, params=params)
-            
-    print(resp.content)
+     
     assert resp.status_code == 200 or resp.status_code == 204 #TODO: check 204 is right
 
     # download from OS to FS is automatic
     download_ok = False
-    for i in range(10):
-        r = requests.get(TASK_URL +"/"+task_id, headers=headers)
+    for i in range(20):
+        r = requests.get(TASKS_URL +"/"+task_id, headers=headers)
         assert r.status_code == 200
-        if r.json()["msg"]["status"] == 114: # import async_tasks -> async_tasks.ST_DWN_END
-	    download_ok = True
+        if r.json()["task"]["status"] == 114: # import async_tasks -> async_tasks.ST_DWN_END
+            download_ok = True
             break
-        sleep(10)
-
+        time.sleep(10)
+    print(r)
     assert download_ok
-
 
 
 

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -94,8 +94,10 @@ def test_post_upload_request(headers):
     for i in range(20):
         r = requests.get(TASKS_URL +"/"+task_id, headers=headers)
         assert r.status_code == 200
-        if r.json()["task"]["status"] == 114: # import async_tasks -> async_tasks.ST_DWN_END
+        if r.json()["task"]["status"] == "114": # import async_tasks -> async_tasks.ST_DWN_END
             download_ok = True
+            break
+        if r.json()["task"]["status"] == "115": # async_task.ST_DWN_ERR
             break
         time.sleep(10)
     print(r)

--- a/src/tests/automated_tests/test-build.ini
+++ b/src/tests/automated_tests/test-build.ini
@@ -2,6 +2,6 @@
 ## test-build
 env_override_existing_values = 1
 env_files =
-    test-build.env
     ../../../deploy/test-build/environment/common.env
     ../../../deploy/test-build/environment/storage.env
+    test-build.env

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -11,17 +11,11 @@ else:
 
 
 
-# test upload request: ask for an upload task (must throw 200 OK), and then
-# inform upload complete (must throw 400 since upload has not been done)
+# test upload request: ask for an upload task (must throw 200 OK)
 def test_post_upload_request(headers):
     data = { "sourcePath": "testsbatch.sh", "targetPath": "/home/testuser" }
     resp = requests.post(STORAGE_URL + "/xfer-external/upload", headers=headers, data=data)
     assert resp.status_code == 200
-
-    task_id = resp.json()["task_id"]
-    headers.update({"X-Task-ID": task_id})
-    r = requests.put(STORAGE_URL + "/xfer-external/upload", headers=headers)
-    assert r.status_code == 400
 
 
 # Test an invalid upload task
@@ -36,13 +30,6 @@ def test_download(headers):
     data = { "sourcePath": "testsbatch.sh" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data)
     assert resp.status_code == 200
-
-
-#def test_exec_upload_finish(headers):
-#    task_id = "0889d6f4f276249312e786e0f9327b83"
-#    headers.update({"X-Task-ID": task_id})
-#    r = requests.put(STORAGE_URL + "/xfer-external/upload", headers=headers)
-#    assert r.status_code == 200
 
 
 def test_internal_cp(headers):


### PR DESCRIPTION
New changes:
- Certificator can issue certificates for a specific command (by now only `wget`) and time.
- Storage: simplified upload process
- `cscs_api_common.get_username`: can extract username for keycloak service account tokens.
- test-build: fix Minio network issue, and updated test-storage pytest