### PR TITLE
compute: fixed jobs listing in acct, and related test

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -815,19 +815,28 @@ def acct():
         data = jsonify(description="Failed to retrieve account information", error=e)
         return data, 400
 
+    
+    # check optional parameter jobs=jobidA,jobidB,jobidC
+    jobs_opt = ""
+
+    jobs = request.args.get("jobs","")
+
+    if jobs != "":
+        jobs_opt = " --jobs={jobs} ".format(jobs=jobs)
 
     # sacct
     # -X so no step information is shown (ie: just jobname, not jobname.batch or jobname.0, etc)
     # --starttime={start_time_opt} starts accounting info
     # --endtime={start_time_opt} end accounting info
+    # --jobs={job1,job2,job3} list of jobs to be reported
     # format: 0 - jobid  1-partition 2-jobname 3-user 4-job sTate,
     #         5 - start time, 6-elapsed time , 7-end time
     #          8 - nodes allocated and 9 - resources
     # --parsable2 = limits with | character not ending with it
 
-    action = "sacct -X {starttime} {endtime} " \
+    action = "sacct -X {starttime} {endtime} {jobs_opt} " \
              "--format='jobid,partition,jobname,user,state,start,cputime,end,NNodes,NodeList' " \
-              "--noheader --parsable2".format(starttime=start_time_opt,endtime=end_time_opt)
+              "--noheader --parsable2".format(starttime=start_time_opt,endtime=end_time_opt, jobs_opt=jobs_opt)
 
     try:
         # obtain new task from Tasks microservice

--- a/src/tests/automated_tests/integration/test_compute.py
+++ b/src/tests/automated_tests/integration/test_compute.py
@@ -83,13 +83,35 @@ def test_cancel_job(machine, headers):
 	resp = submit_job(machine, headers)
 	task_id = resp.json()["task_id"]
 
-	time.sleep(10) # wait until task is runnig
+	time.sleep(10) # wait until task is running
 	job_id = get_job_id(task_id, headers)
 
 	# cancel job
 	url = "{}/{}".format(JOBS_URL, job_id)
 	headers.update({"X-Machine-Name": machine})
 	resp = requests.delete(url, headers=headers)
+	print(resp.content)
+	assert resp.status_code == 200
+
+	# check scancel status
+	task_id = resp.json()["task_id"]
+	check_task_status(resp.json()["task_id"],headers)
+
+# Test account information
+@pytest.mark.parametrize("machine", [SERVER_COMPUTE])
+def test_acct_job(machine, headers):
+
+	resp = submit_job(machine, headers)
+	task_id = resp.json()["task_id"]
+
+	time.sleep(10) # wait until task is running
+	job_id = get_job_id(task_id, headers)
+
+	# cancel job
+	url = "{}/acct".format(COMPUTE_URL)
+	params = {"jobs": job_id}
+	headers.update({"X-Machine-Name": machine})
+	resp = requests.get(url, headers=headers,params=params)
 	print(resp.content)
 	assert resp.status_code == 200
 

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -71,9 +71,11 @@ def test_cancel_job(machine, expected_response_code, headers):
 # Test get account information with sacct command
 @pytest.mark.parametrize("machine, expected_response_code", DATA)
 def test_acct(machine, expected_response_code, headers):
+	jobid = "2,3"
 	url = "{}/acct".format(COMPUTE_URL)
 	headers.update({"X-Machine-Name": machine})
-	resp = requests.get(url, headers=headers)
+	params = {"jobs":jobid}
+	resp = requests.get(url, headers=headers, params=params)
 	print(resp.content)
 	assert resp.status_code == expected_response_code
 


### PR DESCRIPTION
- `GET /compute/acct` wasn't working with `jobs` parameter (`jobs=jobid1,jobid2,...`)
  - Added related tests: integration and automated (`test_compute.py`)

