### PR TITLE
status.py: added FILESYSTEMS parameter

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -52,6 +52,11 @@ KONG_URL=http://192.168.220.10:8000
 # list of systems 
 #public name for systems, where users except to submit jobs and get files (list with ';')
 SYSTEMS_PUBLIC='cluster;cluster'
+# filesystems mounted in each system
+# ; separated for system (position related to SYSTEMS_PUBLIC) and for each filesystem mounted inside each system, separated with ","
+# example: let's suppose SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/home" and "/scratch", and cluster2 has mounted "/home":
+# FILESYSTEMS = "/home,/scratch;/home"
+FILESYSTEMS="/home;/home"
 #internal machines that microservices connect to (in correlation with SYSTEMS_PUBLIC)
 SYSTEMS_INTERNAL_COMPUTE='192.168.220.12:22;192.168.220.12:22'
 SYSTEMS_INTERNAL_STORAGE='192.168.220.12:22;192.168.220.12:22'

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -52,6 +52,11 @@ KONG_URL=
 # list of systems 
 #public name for systems, where users except to submit jobs and get files (list with ';')
 SYSTEMS_PUBLIC='system01;system02'
+# filesystems mounted in each system
+# ; separated for system (position related to SYSTEMS_PUBLIC) and for each filesystem mounted inside each system, separated with ","
+# example: let's suppose SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/home" and "/scratch", and cluster2 has mounted "/home":
+# FILESYSTEMS = "/home,/scratch;/home"
+FILESYSTEMS="/home;/home"
 #internal machines that microservices connect to (in correlation with SYSTEMS_PUBLIC)
 SYSTEMS_INTERNAL_COMPUTE='127.0.0.1:2223;127.0.0.1:2224'
 SYSTEMS_INTERNAL_STORAGE='127.0.0.1:9000;127.0.0.1:2222'

--- a/src/status/status.py
+++ b/src/status/status.py
@@ -24,7 +24,7 @@ SYSTEMS_PUBLIC  = os.environ.get("SYSTEMS_PUBLIC").strip('\'"').split(";")
 # ; separated for system (related with SYSTEMS_PUBLIC length, and for each filesystem mounted inside each system, separated with ":")
 # example: let's suppose SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/fs-c1-1" and "/fs-c1-2", and cluster2 has mounted "/fs-c2-1":
 # FILESYSTEMS = "/fs-c1-1,/fs-c1-2;fs-c2-1"
-FILESYSTEMS = os.environ.get("FILESYSTEMS").split(";")
+FILESYSTEMS = os.environ.get("FILESYSTEMS").strip('\'"').split(";")
 
 SERVICES = os.environ.get("STATUS_SERVICES").strip('\'"').split(";") # ; separated service names
 SYSTEMS  = os.environ.get("STATUS_SYSTEMS").strip('\'"').split(";")  # ; separated systems names

--- a/src/status/status.py
+++ b/src/status/status.py
@@ -21,6 +21,10 @@ import os
 AUTH_HEADER_NAME = 'Authorization'
 
 SYSTEMS_PUBLIC  = os.environ.get("SYSTEMS_PUBLIC").strip('\'"').split(";")
+# ; separated for system (related with SYSTEMS_PUBLIC length, and for each filesystem mounted inside each system, separated with ":")
+# example: let's suppose SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/fs-c1-1" and "/fs-c1-2", and cluster2 has mounted "/fs-c2-1":
+# FILESYSTEMS = "/fs-c1-1,/fs-c1-2;fs-c2-1"
+FILESYSTEMS = os.environ.get("FILESYSTEMS").split(";")
 
 SERVICES = os.environ.get("STATUS_SERVICES").strip('\'"').split(";") # ; separated service names
 SYSTEMS  = os.environ.get("STATUS_SYSTEMS").strip('\'"').split(";")  # ; separated systems names
@@ -369,6 +373,18 @@ def parameters():
 
     # { <microservice>: [ "name": <parameter>,  "value": <value>, "unit": <unit> } , ... ] }
 
+
+    systems = SYSTEMS_PUBLIC # list of systems
+    filesystems = FILESYSTEMS # list of filesystems, position related with SYSTEMS_PUBLIC
+
+    fs_list = []
+
+    for i in range(len(systems)):
+        mounted = filesystems[i].split(",")
+        fs_list.append({"system": systems[i], "mounted": mounted})
+
+    
+
     parameters_list = { "utilities": [
                                         {"name": "UTILITIES_MAX_FILE_SIZE", "value": UTILITIES_MAX_FILE_SIZE, "unit": "MB" },
                                         {"name" :  "UTILITIES_TIMEOUT",      "value": UTILITIES_TIMEOUT, "unit": "seconds"}
@@ -376,7 +392,12 @@ def parameters():
                         "storage": [
                                         {"name":"OBJECT_STORAGE" ,"value":OBJECT_STORAGE, "unit": ""},
                                         {"name":"STORAGE_TEMPURL_EXP_TIME", "value":STORAGE_TEMPURL_EXP_TIME, "unit": "seconds"},
-                                        {"name":"STORAGE_MAX_FILE_SIZE", "value":STORAGE_MAX_FILE_SIZE, "unit": "bytes"}
+                                        {"name":"STORAGE_MAX_FILE_SIZE", "value":STORAGE_MAX_FILE_SIZE, "unit": "bytes"},
+                                        {"name":"FILESYSTEMS", "value":fs_list, "unit": ""}
+                                        
+                                        
+                                        
+                                        
                                 ]
                         }
 


### PR DESCRIPTION
Added `FILESYSTEMS` parameter to `status` microservice giving client the ability to check which filesystems are available in FirecREST:
- Uses `FILESYSTEMS` env var in `common.env`. 
- It returns a list with this format: 

```
[
 {'system': 'cluster1', 'mounted': ['/home', '/scratch']},
 {'system': 'cluster2', 'mounted': ['/home', '/storage', '/scratch']},
]
```