### PR TITLE
Dev 20200423 fix checking path xfer external

### DIFF
--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - "./environment/keys/ca-key:/ca-key:ro"
       - "./environment/keys/user-key.pub:/user-key.pub:ro"
+      - ./logs/firecrest:/var/log:delegated
 
   compute:
     build:
@@ -21,6 +22,7 @@ services:
     network_mode: "host"
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
+      - ./logs/firecrest:/var/log:delegated
 
   status:
     build:
@@ -29,6 +31,8 @@ services:
     env_file:
       - ./environment/common.env
     network_mode: "host"
+    volumes:
+      - ./logs/firecrest:/var/log:delegated
 
   storage:
     build:
@@ -45,6 +49,7 @@ services:
       - "./environment/keys/user-key:/user-key:ro"
       # custom host file
       - "./environment/hosts:/etc/hosts:ro"
+      - ./logs/firecrest:/var/log:delegated
 
   tasks:
     build: 
@@ -59,6 +64,8 @@ services:
     depends_on:
       - "taskpersistence"
     network_mode: "host"
+    volumes:
+      - ./logs/firecrest:/var/log:delegated
 
   utilities:
     build: 
@@ -69,6 +76,7 @@ services:
     network_mode: "host"
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
+      - ./logs/firecrest:/var/log:delegated
 
   # auxiliary containers
   cluster:
@@ -79,6 +87,7 @@ services:
     hostname: cluster
     ports:
       - "2223:22"
+
 
   minio:
     # runs on private network so "cluster" can reach it
@@ -97,3 +106,4 @@ services:
     network_mode: "host"
     volumes:
       - ./taskpersistence/redis.conf:/redis.conf:ro
+      - ./logs/firecrest:/var/log:delegated

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -1613,6 +1613,14 @@ paths:
               description: targetPath is an invalid path.
               schema:
                 type: integer
+            X-Not-A-Directory: 
+              description: targetPath is not a directory
+              schema:
+                type: string
+            X-Error: 
+              description: Error
+              schema:
+                type: string
     put:
       tags: 
         - Storage
@@ -1724,15 +1732,24 @@ paths:
             X-Permission-Denied:
               description: User does not have permissions to access path
               schema:
-                type: integer
+                type: string
             X-Not-Found:
               description: targetPath not found
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: targetPath is an invalid path.
               schema:
-                type: integer
+                type: string
+            X-A-Directory: 
+              description: targetPath is a directory, can't download directories
+              schema:
+                type: string
+            X-Error: 
+              description: Error
+              schema:
+                type: string
+              
   '/tasks':
     get:
       summary: returns all tasks

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -9,6 +9,7 @@ from flask import Flask, request, jsonify
 import keystone
 import json, tempfile, os
 import urllib
+import datetime
 
 import async_task
 import threading
@@ -19,6 +20,7 @@ from cscs_api_common import check_header, get_username
 from cscs_api_common import create_task, update_task, get_task_status
 from cscs_api_common import exec_remote_command, exec_remote_command_cert
 from cscs_api_common import create_certificates
+from cscs_api_common import in_str
 
 # job_time_checker for correct SLURM job time in /xfer-internal tasks
 import job_time
@@ -93,6 +95,115 @@ debug = os.environ.get("DEBUG_MODE", None)
 
 
 app = Flask(__name__)
+
+# checks if path is valid for upload/download file process
+# 'path' should exists and be accesible to the user
+#
+# * for download the sourcePath should be a file that you can read 
+def check_sourcePath(path, auth_header, system):
+
+    # checks user accessibility to path using touch
+    # -r parameter is to not modify timestamp of the file (by modifiying for the same file's timestamp)
+    action = f"touch -r {path} {path}"
+
+    retval = exec_remote_command(auth_header,system,action)
+
+    app.logger.info(retval)
+
+    if retval["error"] != 0:
+        error_str=retval["msg"]
+
+        if retval["error"] == 113:
+            return {"result":False, "headers":{"X-Machine-Not-Available":"Machine is not available"} }
+            
+
+        if retval["error"] == 124:
+            return {"result":False, "headers":{"X-Timeout": "Command has finished with timeout signal"}}
+            
+
+        # error no such file
+        if in_str(error_str,"No such file"):
+            return {"result":False, "headers":{"X-Invalid-Path": "{path} is an invalid path.".format(path=path)}}
+                
+
+        # permission denied
+        if in_str(error_str,"Permission denied"):
+            return {"result":False, "headers":{"X-Permission-Denied": "User does not have permissions to access machine or path"}}
+            
+
+        return {"result":False, "headers":{"X-Error": retval["msg"]}}
+
+    # checks using ls -ld of the path (-d is used for listing dir info not its content)
+    action = f"ls -ld {path}"
+
+    retval = exec_remote_command(auth_header,system,action)
+
+    is_dir = retval["msg"][0]
+    if is_dir ==  "d":
+        return {"result":False, "headers":{"X-A-Directory": "{path} is a directory, can't download directories".format(path=path)}}
+
+
+    return {"result":True}
+
+
+    
+# checks if path is valid for upload/download file process
+# 'path' should exists and be accesible to the user
+#
+# * for upload the targetPath should be a directory where you can write
+def check_targetPath(path, auth_header, system):
+
+    # create an empty file for testing path accesibility
+    # test file is a hidden file and has a timestamp in order to not overwrite other files created by user
+    # after this, file should be deleted
+
+    
+    timestamp = datetime.datetime.today().strftime("%Y-%m-%dT%H:%M:%S.%f")
+    # using a hash 
+    hashedTS  =  md5()
+    hashedTS.update(timestamp.encode("utf-8"))
+
+    tempFileName = f".firecrest.{hashedTS.hexdigest()}"
+
+    action = f"touch {path}/{tempFileName}"
+
+    retval = exec_remote_command(auth_header,system,action)
+
+    app.logger.info(retval)
+
+    if retval["error"] != 0:
+        error_str=retval["msg"]
+
+        if retval["error"] == 113:
+            return {"result":False, "headers":{"X-Machine-Not-Available":"Machine is not available"} }
+            
+
+        if retval["error"] == 124:
+            return {"result":False, "headers":{"X-Timeout": "Command has finished with timeout signal"}}
+            
+
+        # error no such file
+        if in_str(error_str,"No such file"):
+            return {"result":False, "headers":{"X-Invalid-Path": "{path} is an invalid path.".format(path=path)}}
+                
+
+        # permission denied
+        if in_str(error_str,"Permission denied"):
+            return {"result":False, "headers":{"X-Permission-Denied": "User does not have permissions to access machine or path"}}
+
+        # not a directory
+        if in_str(error_str,"Not a directory"):
+            return {"result":False, "headers":{"X-Not-A-Directory": "{path} is not a directory".format(path=path)}}
+            
+
+        return {"result":False, "headers":{"X-Error": retval["msg"]}}    
+
+    # delete test file created
+    action = f"rm {path}/{tempFileName}"
+    retval = exec_remote_command(auth_header,system,action)
+
+
+    return {"result":True}
 
 def file_to_str(fileName):
 
@@ -339,6 +450,13 @@ def download_request():
         data = jsonify(error="Source path not set in request")
         return data, 400
 
+    # checks if sourcePath is a valid path
+    check = check_sourcePath(sourcePath, auth_header, system)
+
+    if not check["result"]:
+        return jsonify(description="sourcePath error"), 400, check["headers"]
+    
+
     # obtain new task from Tasks microservice
     task_id = create_task(auth_header, service="storage")
 
@@ -536,6 +654,12 @@ def upload_request():
     if sourcePath == None:
         data = jsonify(error="Source path not set in request")
         return data, 400
+
+    # checks if sourcePath is a valid path
+    check = check_targetPath(targetPath, auth_header, system)
+
+    if not check["result"]:
+        return jsonify(description="sourcePath error"), 400, check["headers"]
 
 
     # obtain new task from Tasks microservice

--- a/src/tests/automated_tests/readme.txt
+++ b/src/tests/automated_tests/readme.txt
@@ -80,25 +80,25 @@ Finally, you will need to specify the firecrest gateway address in FIRECREST_URL
 
 UPDATE - 04/20/2020
 
-It's possible to test implementations behind a gateway using service account logins.
+It's possible to test implementations behind a gateway using service account(SA) logins.
 You need to setup the following environment variables:
 
 # The gateway url
 FIRECREST_URL = http://myapigateway
 
-# enable login with sa account
+# enable login with SA
 SA_LOGIN      = True 
 
 # Openid service url
 SA_TOKEN_URI  = http://myopenidservice/auth/realms/kcrealm/protocol/openid-connect/token
 
-# The credentials for sa account. 
+# The credentials for SA
 # NOTE: the client must have enabled Service Accounts feature
 SA_SECRET_KEY = mysecret
-SA_CLIENT_ID  = mysaaccount
+SA_CLIENT_ID  = myserviceaccount
 
 The "demo" implementation has been configured to be tested using service account authentication.
-Open demo.env file to check the configuration values that have been setted.
+Open demo.env file to check the configuration values that have been set.
 As previously shown, run the tests on "demo" implementation by executing the following command:
 
     pytest -c demo.ini 

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -30,6 +30,7 @@ def test_download(headers):
     data = { "sourcePath": "testsbatch.sh" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
     print(resp.json())  
+    print(resp.headers)
     assert resp.status_code == 200
 
 

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -28,7 +28,8 @@ def test_put_upload_request(headers):
 
 def test_download(headers):
     data = { "sourcePath": "testsbatch.sh" }
-    resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data)
+    resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
+    print(resp.json())  
     assert resp.status_code == 200
 
 

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -27,7 +27,7 @@ def test_put_upload_request(headers):
 
 
 def test_download(headers):
-    data = { "sourcePath": "testsbatch.sh" }
+    data = { "sourcePath": "./testsbatch.sh" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
     print(resp.json())  
     print(resp.headers)

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -26,12 +26,19 @@ def test_put_upload_request(headers):
     assert r.status_code == 404
 
 
-def test_download(headers):
-    data = { "sourcePath": "./testsbatch.sh" }
+def test_download_file_not_exist(headers):
+    data = { "sourcePath": "no-existing-file" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
     print(resp.json())  
     print(resp.headers)
-    assert resp.status_code == 200
+    assert resp.status_code == 400
+
+def test_download_file_not_allowed(headers):
+    data = { "sourcePath": "/etc/hosts" }
+    resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
+    print(resp.json())  
+    print(resp.headers)
+    assert resp.status_code == 400
 
 
 def test_internal_cp(headers):

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -25,7 +25,6 @@ def test_put_upload_request(headers):
     r = requests.put(STORAGE_URL + "/xfer-external/upload", headers=headers)
     assert r.status_code == 404
 
-
 def test_download_file_not_exist(headers):
     data = { "sourcePath": "no-existing-file" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 

--- a/src/tests/template_client/templates/storage/download.html
+++ b/src/tests/template_client/templates/storage/download.html
@@ -96,9 +96,22 @@ function update_progress(task_url) {
 
       </div>
     {% else %}
-      <div class="bg-danger" id="error"> Error: {{ response.json()["error"] }}</div>
-    {% endif %}
-  {% else %}
+
+    
+      {% set error_headers = ["X-Machine-Does-Not-Exist","X-Machine-Not-Available","X-Permission-Denied","X-Invalid-Path","X-Error","X-A-Directory"] %}
+
+      <div class="bg-danger"><b>Error:</b> Description: {{ response.json()["description"] }}:
+
+              {% for header,value in response.headers.items() %}
+                {% if header in error_headers %}
+                  Reason: {{ header }}: {{ value }}
+                   {%  break %}
+                {% endif %}
+              {% endfor %}
+         </div>
+    {%  endif %}
+  {%  endif %}
+  
     <h2>Select directory where file is stored in CSCS</h2>
         {# {{ wtf.quick_form(form) }} #}
       <form method="post" action="download" class="form-group">
@@ -109,5 +122,5 @@ function update_progress(task_url) {
 
       </form>
 
-  {% endif %}
+  
 {% endblock %}

--- a/src/tests/template_client/templates/storage/upload.html
+++ b/src/tests/template_client/templates/storage/upload.html
@@ -12,13 +12,21 @@
 
   {% if response != None %}
     {% if not response.ok %}
-      <div class="bg-danger" style="display: block; border-color: red; border-style: solid" id="error">
-	    <h3>Error</h3>
-	    <p>{{ response.json()["error"] }}</p>
-	    <a href="{{ request.url_root}}storage/upload">Try again</a>
-	  </div>
+      
+      {% set error_headers = ["X-Machine-Does-Not-Exist","X-Machine-Not-Available","X-Permission-Denied","X-Invalid-Path","X-Not-A-Directory","X-Error"] %}
+
+      <div class="bg-danger"><b>Error:</b> Description: {{ response.json()["description"] }}:
+
+              {% for header,value in response.headers.items() %}
+                {% if header in error_headers %}
+                  Reason: {{ header }}: {{ value }}
+                  {%  break %}
+                {% endif %}
+              {% endfor %}
+      </div>
     {% endif %}
-  {% else %}
+  {% endif %}
+  
     <h2>Step 1: Select directory where to store file in CSCS and your local file</h2>
 
       <form class="form-group" action="upload" method="post">
@@ -28,5 +36,6 @@
             <tr><td style="padding-right: 20px">{{ form.submit(class="form-control") }}</td></tr>
         </table>
       </form>
-  {% endif %}
+
+  
 {% endblock %}


### PR DESCRIPTION
- Changes in `storage` for external transfers:
  - `storage/xfer-external/upload` now checks that `targetPath` is a directory and exists
  - `storage/xfer-external/download` now checks that `sourcePath` is a file and exists
- Changes in `test_unit_storage.py` to check these functionalities.
- Changes in `docs/openapi/firecrest-developer-api.yml` adding new error headers related to storage.
- Changes in the client `firecrest-demo.py`(template files) to handle new errors.

