### PR TITLE
Restapi 526 advanced features for compute microservice

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -54,6 +54,7 @@ TAIL_BYTES = os.environ.get("F7T_TAIL_BYTES",1000)
 
 #max file size for sbatch upload in MB (POST compute/job)
 MAX_FILE_SIZE=int(os.environ.get("F7T_UTILITIES_MAX_FILE_SIZE"))
+TIMEOUT = int(os.environ.get("F7T_UTILITIES_TIMEOUT"))
 
 app = Flask(__name__)
 # max content lenght for upload in bytes
@@ -347,13 +348,13 @@ def get_slurm_files(auth_header, machine, task_id,job_info,output=False):
         # tail -n {number_of_lines_since_end} or
         # tail -c {number_of_bytes} --> 1000B = 1KB
        
-        action = f"tail -c {TAIL_BYTES} {control_info['job_file_out']}"
+        action = f"timeout {TIMEOUT} tail -c {TAIL_BYTES} {control_info['job_file_out']}"
         resp = exec_remote_command(auth_header, machine, action)
         if resp["error"] == 0:
             control_info["job_data_out"] = resp["msg"]
         
    
-        action = f"tail -c {TAIL_BYTES} {control_info['job_file_err']}"
+        action = f"timeout {TIMEOUT} tail -c {TAIL_BYTES} {control_info['job_file_err']}"
         resp = exec_remote_command(auth_header, machine, action)
         if resp["error"] == 0:
             control_info["job_data_err"] = resp["msg"]

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -380,9 +380,6 @@ def submit_job_task(auth_header,machine,fileName,tmpdir,task_id):
         update_task(task_id, auth_header, async_task.ERROR, resp["msg"])
         return
 
-    # if job was submited succesfully, then "msg" is a dictionary with jobid field
-    update_task(task_id, auth_header, async_task.SUCCESS, resp["msg"],True)
-
     # now looking for log and err files location
     job_extra_info = get_slurm_files(auth_header, machine, task_id,resp["msg"])
 

--- a/src/tests/template_client/templates/compute/job.html
+++ b/src/tests/template_client/templates/compute/job.html
@@ -5,10 +5,10 @@
 --  SPDX-License-Identifier: BSD-3-Clause
   -->
 {% extends "demo_base.html" %}
-{% block title %}List jobs{% endblock %}
+{% block title %}List single job{% endblock %}
 {% block content %}
 <style>
-table {
+/*table {
   font-family: arial, sans-serif;
   border-collapse: collapse;
   width: 100%;
@@ -22,7 +22,7 @@ td, th {
 
 tr:nth-child(even) {
   background-color: #dddddd;
-}
+}*/
 </style>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -45,17 +45,25 @@ function update_progress(task_url) {
         type: 'GET',
         url: task_url,
         success: function(data){
-          $(".task").css("border-color","green");
-          $(".task").css("border-style","solid");
+          /*$(".task").css("border-color","green");
+          $(".task").css("border-style","solid");*/
 
           var resp = data['task']['data'];
 
+          if (data["task"]["status"] == "200"){
+            $(".task").addClass("bg-success");
+
+          }
+          else{
+            $(".task").addClass("bg-danger");
+          }
 
           console.log(resp.length);
           console.log(resp);
           
           if(is_object(resp)){
-		$(".task").text("You have active jobs");
+            
+		      $(".task").text("You have active jobs");
 		
                 var row_number = 1; /*starts with 1, because 0 is table header*/
                 for (var key in resp){
@@ -85,7 +93,23 @@ function update_progress(task_url) {
 				time_left.innerHTML = resp[key]["time_left"];
 				
 				var actions = row.insertCell(9);
-				actions.innerHTML = "<a href='{{ request.url_root }}compute/cancel/"+resp[key]["jobid"]+"?machine={{ request.args.get("machine") }}'>Cancel</a>";			
+        actions.innerHTML = "<a href='{{ request.url_root }}compute/cancel/"+resp[key]["jobid"]+"?machine={{ request.args.get("machine") }}'>Cancel</a>";	
+        
+        
+        var log_file_path = document.getElementById("td_log_file");
+        var err_file_path = document.getElementById("td_err_file");
+
+        log_file_path.innerHTML = resp[key]["StdOut"];
+        err_file_path.innerHTML = resp[key]["StdErr"];
+
+        var text_log_file = document.getElementById("text_log_file");
+        var text_err_file = document.getElementById("text_err_file");
+
+        var out_data = resp[key]["StdOutData"].replace("$", '<br>');
+
+        text_log_file.innerText = out_data;
+        text_err_file.innerText = resp[key]["StdErrData"];
+        
 
 				row_number+=1;
 			}
@@ -101,8 +125,9 @@ function update_progress(task_url) {
        },
 
         error: function(data){
-          $(".task").css("border-color","red");
-          $(".task").css("border-style","solid");
+          /*$(".task").css("border-color","red");
+          $(".task").css("border-style","solid");*/
+          $(".task").addClass("bg-danger");
           $( ".task" ).text("Error on submiting request\n"+data['error']);
 
           },
@@ -132,9 +157,17 @@ function update_progress(task_url) {
       <div class="task"></div><br>
 
       <div class="job_list">
-           	<table id="job_table">
+           	<table class="table table-hover" id="job_table">
                 <tr><th>Job ID</th><th>Job Name</th><th>Node List</th><th>Nodes</th><th>Partition</th><th>Start Time</th><th>State</th><th>Time</th><th>Time Left</th><th>Options</th></tr>
-		</table>
+    </table>
+    
+    <table class="table table-hover" id="job_result"> 
+      <tr><th>Log file</th><td id="td_log_file"></td></tr>
+      <tr><th>Log file content</th><td id="td_log_file_cnt"><textarea cols="100" rows="10" id="text_log_file"></textarea></td></tr>
+      <tr><th>Err file</th><td id="td_err_file"></td></tr>
+      <tr><th>Err file content</th><td id="td_err_file_cnt"><textarea cols="100" rows="10" id="text_err_file"></textarea></td></tr>
+
+    </table>
       </div>
     {% else %}
       {{ response.json()['error'] }}


### PR DESCRIPTION
Added support for viewing SLURM files localization and progression (using `scontrol` command).

Now tasks related to job submission and job query will present new fields in the response:

  - `jobfile`: localization of sbatch file submitted.
  - `StdErr`: localization of sbatch error log.
  - `StdOut`: localization of sbatch output log.
  - `StdErrData`: last F7T_TAIL_BYTES bytes of data of sbatch error log (only available in job query)
  - `StdOut`: last F7T_TAIL_BYTES bytes of data of sbatch output log (only available in job query)

Example of a job query task response:

```
"task": {
    "data": {
      "0": {
                { 
                  "jobid": 3,                        
                  "StdErr": "$SCRATCH/firecrest/08a1c943a79134000a07d55618e6fc1c/sbatch.error",
                  "StdErrData": "",
                 "StdOut": "$SCRATCH/firecrest/08a1c943a79134000a07d55618e6fc1c/sbatch.output",
                 "StdOutData": "Job started at: Fri May 15 10:10:04 UTC 2020\\n",
                  "jobfile": "$SCRATCH/firecrest/08a1c943a79134000a07d55618e6fc1c/sbatch.sh",
                 ....
}