### PR TITLE
Restapi 549 compute fix sbatch file creation

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -197,6 +197,9 @@ def paramiko_scp(auth_header, cluster, sourcePath, targetPath):
 
         stdin.channel.shutdown_write()
         sourceFile.close()
+        
+        # wait for cat command to finish
+        stdout.channel.recv_exit_status()
         # END: write sbatch file
 
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -190,7 +190,7 @@ def paramiko_scp(auth_header, cluster, sourcePath, targetPath):
         sourceFile = open(sourcePath,"r")
 
         action = "cat > {targetPath}/{sourcePath}".format(targetPath=targetPath,sourcePath=sourcePath)
-	app.logger.info(action)
+        app.logger.info(action)
 
         stdin, stdout, stderr = client.exec_command(action)
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -190,6 +190,7 @@ def paramiko_scp(auth_header, cluster, sourcePath, targetPath):
         sourceFile = open(sourcePath,"r")
 
         action = "cat > {targetPath}/{sourcePath}".format(targetPath=targetPath,sourcePath=sourcePath)
+	app.logger.info(action)
 
         stdin, stdout, stderr = client.exec_command(action)
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -186,7 +186,7 @@ def paramiko_scp(auth_header, cluster, sourcePath, targetPath):
         ## end create tmpdir
 
 
-        # write sbatch file
+        # write sbatch file 
         sourceFile = open(sourcePath,"r")
 
         action = "cat > {targetPath}/{sourcePath}".format(targetPath=targetPath,sourcePath=sourcePath)


### PR DESCRIPTION
Fixes applied to job submission in compute.py :
* Cat command execution was changed to synchronous/blocking mode.
* Error checking for cat command was added.