### PR TITLE
compute: added F7T_COMPUTE_BASE_FS env var for FS selection of job di…

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -54,7 +54,7 @@ F7T_KONG_URL=http://192.168.220.10:8000
 F7T_SYSTEMS_PUBLIC='cluster;cluster'
 # filesystems mounted in each system
 # ; separated for system (position related to SYSTEMS_PUBLIC) and for each filesystem mounted inside each system, separated with ","
-# example: let's suppose SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/home" and "/scratch", and cluster2 has mounted "/home":
+# example: let's suppose F7T_SYSTEMS_PUBLIC="cluster1;cluster2", cluster1 has "/home" and "/scratch", and cluster2 has mounted "/home":
 # F7T_FILESYSTEMS = "/home,/scratch;/home"
 F7T_FILESYSTEMS="/home;/home"
 #internal machines that microservices connect to (in correlation with SYSTEMS_PUBLIC)
@@ -63,7 +63,9 @@ F7T_SYSTEMS_INTERNAL_STORAGE='192.168.220.12:22;192.168.220.12:22'
 F7T_SYSTEMS_INTERNAL_UTILITIES='192.168.220.12:22;192.168.220.12:22'
 #-------
 # COMPUTE options
-F7T_JOB_BASE_DIR=$HOME
+# Base filesystem where job submission files will be stored.
+# ; separated for system
+F7T_COMPUTE_BASE_FS="/home;/home"
 #-------
 # Storage:
 # public systems to send a job for internal transfer (xfer), must be defined in SYSTEMS_PUBLIC

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -62,8 +62,10 @@ F7T_SYSTEMS_INTERNAL_COMPUTE='127.0.0.1:2223;127.0.0.1:2224'
 F7T_SYSTEMS_INTERNAL_STORAGE='127.0.0.1:9000;127.0.0.1:2222'
 F7T_SYSTEMS_INTERNAL_UTILITIES='127.0.0.1:2223;127.0.0.1:2222'
 #-------
-# JOBS options
-F7T_JOB_BASE_DIR=$HOME
+# COMPUTE option
+# Base filesystem where job submission files will be stored.
+# ; separated for system
+F7T_COMPUTE_BASE_FS="/home;/home"
 #-------
 # Storage:
 # public systems to send a job for internal transfer (xfer), must be defined in SYSTEMS_PUBLIC

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -385,7 +385,7 @@ def submit_job_task(auth_header,machine,fileName,job_dir,task_id):
     # it's delivered by another instance of Jobs,
     # and this function is not an entry point
 
-    resp = paramiko_scp(auth_header, machine, fileName, f"{job_dir}")
+    resp = paramiko_scp(auth_header, machine, fileName, job_dir)
 
     # in case of error:
     if resp["error"] == -2:


### PR DESCRIPTION
With this workaround now sbatch files will be stored in a filesystem depending on the machine where it is running (since `$HOME` or `$SCRATCH` might not be available as env vars for some systems).

New env var in `common.env` called `F7T_COMPUTE_BASE_FS`, with is a semicolon-separated list of filesystems available depending on the index of the machine chosen (ie: it's related to `F7T_SYSTEMS_PUBLIC` index).
This new var replaces `F7T_JOB_BASE_DIR`

- Also: removed `cd` command before `sbatch` execution and using now `--chdir` option suggested by @aledabin 