### PR TITLE
Restapi 548 ssh command server side filter poc

### DIFF
--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -75,5 +75,8 @@ RUN chmod -R 400 /etc/ssh/  && chown -R root:root /etc/ssh/
 
 RUN /usr/libexec/mariadb-prepare-db-dir 2>/dev/null
 
+ADD cluster/ssh/ssh_command_wrapper.sh /ssh_command_wrapper.sh
+RUN chmod 555 /ssh_command_wrapper.sh
+
 ENTRYPOINT ["/usr/bin/supervisord"]
 

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# temp log dir
+log_dir=/tmp
+
+date >> ${log_dir}/ssh-original-$UID.txt
+echo "${SSH_ORIGINAL_COMMAND}" >> ${log_dir}/ssh-original-$UID.txt
+
+command=${SSH_ORIGINAL_COMMAND%% *}    # remove all after first space
+
+case "$command" in
+    cat|mkdir|rm|touch)
+        ;;
+    timeout)
+        # sintax: timeout number command optins
+        tmp1=${SSH_ORIGINAL_COMMAND#* }   # remove after first space
+        duration=${tmp1%% *}              # remove all after first space
+        tmp2=${tmp1#* }
+        command2=${tmp2%% *}   # remove options
+
+        case "$command2" in
+            chmod|chown|cp|file|ln|ls|mkdir|mv|rm|stat|tail|touch|sbatch|squeue|scontrol|wget)
+                ;;
+            *)
+                echo "Unhandled timeout command: ${SSH_ORIGINAL_COMMAND}" >>  ${log_dir}/ssh-unhandled-timeout-$UID.txt
+                ;;
+        esac
+        ;;
+    sacct|sbatch|scancel|scontrol|squeue)
+        # valid Slurm commands
+        ;;
+    wget)
+        # from object storage
+        ;;
+    /usr/libexec/openssh/sftp-server)
+        # SFTP transfer
+        ;;
+    *)
+        echo "Unhandled command: ${SSH_ORIGINAL_COMMAND}" >>  ${log_dir}/ssh-unhandled-$UID.txt
+        ;;
+esac
+
+# execute original command
+eval ${SSH_ORIGINAL_COMMAND}

--- a/deploy/test-build/cluster/ssh/sshd_config
+++ b/deploy/test-build/cluster/ssh/sshd_config
@@ -107,3 +107,6 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
     #AllowUsers user1
     MaxAuthTries 1
     AllowTcpForwarding no
+    ForceCommand /ssh_command_wrapper.sh
+    PermitTTY no
+    PermitTunnel no

--- a/deploy/test-build/cluster/supervisord.conf
+++ b/deploy/test-build/cluster/supervisord.conf
@@ -19,7 +19,9 @@ user=munge
 priority=5
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/sbin/sshd -D -e
+stdout_logfile=/var/log/sshd_out.log
+redirect_stderr=true
 priority=6
 
 [program:slurmctld]

--- a/src/utilities/utilities.py
+++ b/src/utilities/utilities.py
@@ -237,8 +237,7 @@ def paramiko_download(auth_header, cluster, path):
                        timeout=2)
 
         # check file size not over SIZE_LIMIT
-
-        action = "stat --dereference -c %s -- '{path}'".format(path=path)
+        action = f"timeout {UTILITIES_TIMEOUT} stat --dereference -c %s -- '{path}'"
         stdin, stdout, stderr = client.exec_command(action)
 
         # error status
@@ -366,7 +365,7 @@ def file_type():
         return jsonify(description="Error in file operation",error="'targetPath' query string missing"), 400
 
 
-    action = "timeout {timeout} file -b -- '{path}'".format(timeout=UTILITIES_TIMEOUT, path=path)
+    action = f"timeout {UTILITIES_TIMEOUT} file -b -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -449,7 +448,7 @@ def chmod():
         return jsonify(description="Error in chmod operation", error="mode query string missing"), 400
 
     # using -c flag for verbose mode in stdout
-    action = "timeout {timeout} chmod -v '{mode}' -- '{path}'".format(timeout=UTILITIES_TIMEOUT,mode=mode,path=path)
+    action = f"timeout {UTILITIES_TIMEOUT} chmod -v '{mode}' -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -539,8 +538,7 @@ def chown():
         return jsonify(description="Error in chown operation", error="group and/or owner should be set"), 400
 
 
-    action = "timeout {timeout} chown -v '{owner}':'{group}' -- '{path}'".format(
-                    timeout=UTILITIES_TIMEOUT,owner=owner,group=group,path=path)
+    action = f"timeout {UTILITIES_TIMEOUT} chown -v '{owner}':'{group}' -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -634,7 +632,7 @@ def list_directory():
     #         path=path, showall=showall)
 
     # changed since bash only captures errors from the last command in pipeline, and this always was OK
-    action = "timeout {timeout} ls -l {showall} --time-style=+%Y-%m-%dT%H:%M:%S -- '{path}' ".format(path=path, showall=showall,timeout=UTILITIES_TIMEOUT)
+    action = f"timeout {UTILITIES_TIMEOUT} ls -l {showall} --time-style=+%Y-%m-%dT%H:%M:%S -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -782,7 +780,7 @@ def make_directory():
     except BadRequestKeyError:
         parent = ""
 
-    action = "timeout {timeout} mkdir {parent} -- '{path}'".format(timeout=UTILITIES_TIMEOUT,path=path,parent=parent)
+    action = f"timeout {UTILITIES_TIMEOUT} mkdir {parent} -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -823,84 +821,7 @@ def make_directory():
 
 @app.route("/rename", methods=["PUT"])
 def rename():
-    # checks if AUTH_HEADER_NAME is set
-    try:
-        auth_header = request.headers[AUTH_HEADER_NAME]
-    except KeyError as e:
-        app.logger.error("No Auth Header given")
-        return jsonify(description="No Auth Header given"), 401
-
-    if not check_header(auth_header):
-        return jsonify(description="Invalid header"), 401
-
-    try:
-        machinename = request.headers["X-Machine-Name"]
-    except KeyError as e:
-        app.logger.error("No machinename given")
-        return jsonify(description="No machine name given"), 400
-
-    # public endpoints from Kong to users
-    if machinename not in SYSTEMS_PUBLIC:
-        header = {"X-Machine-Does-Not-Exist": "Machine does not exist"}
-        return jsonify(description="Error on rename operation", error="Machine does not exist"), 400, header
-
-    # iterate over systems list and find the endpoint matching same order
-    for i in range(len(SYSTEMS_PUBLIC)):
-        if SYSTEMS_PUBLIC[i] == machinename:
-            machine = SYS_INTERNALS[i]
-            break
-
-    try:
-        sourcePath = request.form["sourcePath"]
-    except BadRequestKeyError:
-        return jsonify(description="Error on rename operation", error="'sourcePath' query string missing"), 400
-
-    try:
-        targetPath = request.form["targetPath"]
-    except BadRequestKeyError:
-        return jsonify(description="Error on rename operation", error="newpath query string missing"), 400
-
-    # action to execute
-    action = "echo n | timeout {timeout} mv -i -- '{sourcePath}' '{targetPath}'".format(
-                            timeout=UTILITIES_TIMEOUT,sourcePath=sourcePath, targetPath=targetPath)
-
-    retval = exec_remote_command(auth_header, machine, action)
-
-    if retval["error"] != 0:
-        error_str=retval["msg"]
-
-        if retval["error"] == 113:
-            header = {"X-Machine-Not-Available":"Machine is not available"}
-            return jsonify(description="Error on rename operation"), 400, header
-
-        if retval["error"] == 124:
-            header = {"X-Timeout": "Command has finished with timeout signal"}
-            return jsonify(description="Error on rename operation"), 400, header
-
-        # error no such file
-        if in_str(error_str,"No such file"):
-            if in_str(error_str,"cannot stat"):
-                header={"X-Not-Found":"{sourcePath} not found.".format(sourcePath=sourcePath)}
-                return jsonify(description="Error on rename operation"), 400, header
-
-            if in_str(error_str,"cannot move"):
-                header = {"X-Invalid-Path": "{sourcePath} and/or {targetPath} are invalid paths.".format(sourcePath=sourcePath,targetPath=targetPath)}
-                return jsonify(description="Error on rename operation"), 400, header
-
-        # permission denied
-        if in_str(error_str,"Permission denied"):
-            header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
-            return jsonify(description="Error on rename operation"), 400, header
-
-        # if already exists, not overwrite (-i)
-        if in_str(error_str,"overwrite"):
-            header = {"X-Exists": "{targetPath} already exists".format(targetPath=targetPath)}
-            return jsonify(description="Error on rename operation"), 400, header
-
-        return jsonify(description="Error on rename operation",error=error_str), 400
-
-
-    return jsonify(description="Success to rename file or directory.", output=""), 200
+    return common_operation(request, "rename", "PUT")
 
 
 
@@ -953,17 +874,18 @@ def common_operation(request, command, method):
     except BadRequestKeyError:
         return jsonify(description="Error on " + command + " operation", error="target query string missing"), 400
 
-    
+
     if command == "copy":
         # action to execute
-        # -i is for interactive, when user asks for confirmation, given with "echo n"
         # -r is for recursivelly copy files into directories
-        action = "echo n | timeout {timeout} cp -i -dR --preserve=all -- '{sourcePath}' '{targetPath}'".format(
-            timeout=UTILITIES_TIMEOUT, sourcePath=sourcePath, targetPath=targetPath)
+        action = f"timeout {UTILITIES_TIMEOUT} cp --force -dR --preserve=all -- '{sourcePath}' '{targetPath}'"
+        success_code = 201
     elif command == "rename":
-        action = "echo n | timeout {timeout} mv -i -- '{sourcePath}' '{targetPath}'".format(
-            timeout=UTILITIES_TIMEOUT, sourcePath=sourcePath, targetPath=targetPath)
-
+        action = f"timeout {UTILITIES_TIMEOUT} mv --force -- '{sourcePath}' '{targetPath}'"
+        success_code = 200
+    else:
+        app.logger.error("Unknown command on common_operation: " + command)
+        return jsonify(description="Error on unkownon operation", error="Unknown"), 400
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -1001,7 +923,7 @@ def common_operation(request, command, method):
 
         return jsonify(description="Error on copy operation"), 400
 
-    return jsonify(description="Success to " + command + " file or directory.", output=""), 201
+    return jsonify(description="Success to " + command + " file or directory.", output=""), success_code
 
 
 
@@ -1046,7 +968,7 @@ def rm():
 
     # action to execute
     # -r is for recursivelly delete files into directories
-    action = "echo n | timeout {timeout} rm -r -- '{path}'".format(timeout=UTILITIES_TIMEOUT,path=path)
+    action = f"timeout {UTILITIES_TIMEOUT} rm -fr -- '{path}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 
@@ -1124,8 +1046,7 @@ def symlink():
     except BadRequestKeyError:
         return jsonify(description="Failed to create symlink",error="'targetPath' query string missing"), 400
 
-    action = "timeout {timeout} ln -s -- '{targetPath}' '{linkPath}'".format(
-                timeout=UTILITIES_TIMEOUT,targetPath=targetPath,linkPath=linkPath)
+    action = f"timeout {UTILITIES_TIMEOUT} ln -s -- '{targetPath}' '{linkPath}'"
 
     retval = exec_remote_command(auth_header, machine, action)
 


### PR DESCRIPTION
- SSH server on cluster has wrapper that logs every command (`deploy/test-build/cluster/ssh/ssh_command_wrapper.sh`)
- Utilities force actions (cp, mv, etc) and avoid `echo n`
- Storage: when downloading from OS using a certificate with `force-command`,  also send command so wrapper on SSH server can execute it.