### PR TITLE
Restapi 557 fix error output for not valid ssh certificate

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -457,10 +457,24 @@ def submit_job():
 
     # iterate over SYSTEMS_PUBLIC list and find the endpoint matching same order
 
-    indx = SYSTEMS_PUBLIC.index(machine)
-    machine = SYS_INTERNALS[indx]
+    # select index in the list corresponding with machine name
+    machine_idx = SYSTEMS_PUBLIC.index(machine)
+    machine = SYS_INTERNALS[machine_idx]
 
-    job_base_fs = COMPUTE_BASE_FS[indx] 
+    # check if machine is accessible by user:
+    # exec test remote command
+    resp = exec_remote_command(auth_header, machine, "hostname")
+
+    if resp["error"] != 0:
+        error_str = resp["msg"]
+        if resp["error"] == -2:
+            header = {"X-Machine-Not-Available": "Machine is not available"}
+            return jsonify(description="Failed to submit job file"), 400, header
+        if in_str(error_str,"Permission") or in_str(error_str,"OPENSSH"):
+            header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
+            return jsonify(description="Failed to submit job file"), 404, header
+
+    job_base_fs = COMPUTE_BASE_FS[machine_idx] 
 
     try:
         # check if the post request has the file part
@@ -550,11 +564,22 @@ def list_jobs():
         header = {"X-Machine-Does-Not-Exists": "Machine does not exists"}
         return jsonify(description="Failed to retrieve jobs information", error="Machine does not exists"), 400, header
 
-    # iterate over SYSTEMS_PUBLIC list and find the endpoint matching same order
-    for i in range(len(SYSTEMS_PUBLIC)):
-        if SYSTEMS_PUBLIC[i] == machine:
-            machine = SYS_INTERNALS[i]
-            break
+    # select index in the list corresponding with machine name
+    machine_idx = SYSTEMS_PUBLIC.index(machine)
+    machine = SYS_INTERNALS[machine_idx]
+
+    # check if machine is accessible by user:
+    # exec test remote command
+    resp = exec_remote_command(auth_header, machine, "hostname")
+
+    if resp["error"] != 0:
+        error_str = resp["msg"]
+        if resp["error"] == -2:
+            header = {"X-Machine-Not-Available": "Machine is not available"}
+            return jsonify(description="Failed to retrieve jobs information"), 400, header
+        if in_str(error_str,"Permission") or in_str(error_str,"OPENSSH"):
+            header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
+            return jsonify(description="Failed to retrieve jobs information"), 404, header
 
     username = get_username(auth_header)
 
@@ -728,11 +753,22 @@ def list_job(jobid):
         header = {"X-Machine-Does-Not-Exists": "Machine does not exists"}
         return jsonify(description="Failed to retrieve job information", error="Machine does not exists"), 400, header
 
-    # iterate over SYSTEMS_PUBLIC list and find the endpoint matching same order
-    for i in range(len(SYSTEMS_PUBLIC)):
-        if SYSTEMS_PUBLIC[i] == machine:
-            machine = SYS_INTERNALS[i]
-            break
+    # select index in the list corresponding with machine name
+    machine_idx = SYSTEMS_PUBLIC.index(machine)
+    machine = SYS_INTERNALS[machine_idx]
+
+    # check if machine is accessible by user:
+    # exec test remote command
+    resp = exec_remote_command(auth_header, machine, "hostname")
+
+    if resp["error"] != 0:
+        error_str = resp["msg"]
+        if resp["error"] == -2:
+            header = {"X-Machine-Not-Available": "Machine is not available"}
+            return jsonify(description="Failed to retrieve job information"), 400, header
+        if in_str(error_str,"Permission") or in_str(error_str,"OPENSSH"):
+            header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
+            return jsonify(description="Failed to retrieve job information"), 404, header
 
     username = get_username(auth_header)
     app.logger.info("Getting SLURM information of job={jobid} from {machine}".
@@ -831,11 +867,22 @@ def cancel_job(jobid):
         header = {"X-Machine-Does-Not-Exists": "Machine does not exists"}
         return jsonify(description="Failed to delete job", error="Machine does not exists"), 400, header
 
-    # iterate over SYSTEMS_PUBLIC list and find the endpoint matching same order
-    for i in range(len(SYSTEMS_PUBLIC)):
-        if SYSTEMS_PUBLIC[i] == machine:
-            machine = SYS_INTERNALS[i]
-            break
+    # select index in the list corresponding with machine name
+    machine_idx = SYSTEMS_PUBLIC.index(machine)
+    machine = SYS_INTERNALS[machine_idx]
+
+    # check if machine is accessible by user:
+    # exec test remote command
+    resp = exec_remote_command(auth_header, machine, "hostname")
+
+    if resp["error"] != 0:
+        error_str = resp["msg"]
+        if resp["error"] == -2:
+            header = {"X-Machine-Not-Available": "Machine is not available"}
+            return jsonify(description="Failed to delete job"), 400, header
+        if in_str(error_str,"Permission") or in_str(error_str,"OPENSSH"):
+            header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
+            return jsonify(description="Failed to delete job"), 404, header
 
 
     app.logger.info("Cancel SLURM job={jobid} from {machine}".
@@ -936,11 +983,22 @@ def acct():
         header = {"X-Machine-Does-Not-Exists": "Machine does not exists"}
         return jsonify(description="Failed to retrieve account information", error="Machine does not exists"), 400, header
 
-    # iterate over SYSTEMS_PUBLIC list and find the endpoint matching same order
-    for i in range(len(SYSTEMS_PUBLIC)):
-        if SYSTEMS_PUBLIC[i] == machine:
-            machine = SYS_INTERNALS[i]
-            break
+    # select index in the list corresponding with machine name
+    machine_idx = SYSTEMS_PUBLIC.index(machine)
+    machine = SYS_INTERNALS[machine_idx]
+
+    # check if machine is accessible by user:
+    # exec test remote command
+    resp = exec_remote_command(auth_header, machine, "hostname")
+
+    if resp["error"] != 0:
+        error_str = resp["msg"]
+        if resp["error"] == -2:
+            header = {"X-Machine-Not-Available": "Machine is not available"}
+            return jsonify(description="Failed to retrieve account information"), 400, header
+        if in_str(error_str,"Permission") or in_str(error_str,"OPENSSH"):
+            header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
+            return jsonify(description="Failed to retrieve account information"), 404, header
 
     #check if startime (--startime=) param is set:
     start_time_opt = ""

--- a/src/utilities/utilities.py
+++ b/src/utilities/utilities.py
@@ -113,39 +113,7 @@ def paramiko_upload(auth_header, cluster, local_path, remote_path):
         remote_file.write(local_data)
         result = {"error": 0, "msg": remote_path_file}
         remote_file.close()
-
-
-        # try:
-        #     remote_file = ftp_client.file(remote_path_file, "w")
-        #     remote_file.write(local_data)
-        #     result = {"error": 0, "msg": remote_path_file}
-        # except PermissionError as pe:
-        #     app.logger.error("Permission error {strerr}".format(strerr=pe.errno))
-        #     app.logger.error("Errno {errno}".format(errno=pe.strerror))
-        #     result = {"error": pe.errno, "msg": pe.strerror}
-        # except Exception as e:
-        #     app.logger.error(type(e))
-        #     app.logger.error(e)
-        #     result = {"error": 1, "msg": e}
-        # finally:
-        #     remote_file.close()
-        #     # closing client
-        #     app.logger.info("Closing clients")
-        #     ftp_client.close()
-        #     client.close()
-
-        #     app.logger.info("Removing temp certs")
-        #     # removing temporary keys, certs and dirs
-        #     os.remove(pub_cert)
-        #     os.remove(pub_key)
-        #     os.remove(priv_key)
-        #     os.rmdir(temp_dir)
-
-        #     app.logger.info("Returned: {result}".format(result=result))
-
-        #     return result
-
-        
+ 
 
     except PermissionError as pe:
         app.logger.error("Permission error {strerr}".format(strerr=pe.errno))
@@ -178,15 +146,21 @@ def paramiko_upload(auth_header, cluster, local_path, remote_path):
         app.logger.error(e.filename)
         app.logger.error(e.errno)        
         result = {"error": e.errno, "msg": "IOError"}
+    
+    except paramiko.ssh_exception.SSHException as e:
+        logging.error(e, exc_info=True)
+        app.logger.error(e)        
+        result = {"error":1, "msg":e.args[0]}
 
     except Exception as e:
-        app.logger.error(e)
-        result = {"error": 1, "msg": e}
+        app.logger.error(e.args)
+        result = {"error": 1, "msg": e.args[0]}
     finally:
         # closing client
         app.logger.info("Closing clients")
        
-        ftp_client.close()
+        if "ftp_client" in locals():
+            ftp_client.close()
         client.close()
 
         app.logger.info("Removing temp certs")
@@ -312,10 +286,14 @@ def paramiko_download(auth_header, cluster, path):
         app.logger.error(e.errno)
         app.logger.error(e.strerror)
         result = {"error": e.errno, "msg": "IOError"}
+    except paramiko.ssh_exception.SSHException as e:
+        logging.error(e, exc_info=True)
+        app.logger.error(e)        
+        result = {"error":1, "msg":e.args[0]}
     except Exception as e:
         logging.error(e, exc_info=True)
         app.logger.error(e)
-        result = {"error":1, "msg":e}
+        result = {"error":1, "msg":e.args[0]}
 
 
     os.remove(pub_cert)
@@ -382,7 +360,7 @@ def file_type():
             return jsonify(description="Error in file operation"), 400, header
 
         #in case of permission for other user
-        if in_str(error_str,"Permission"):
+        if in_str(error_str,"Permission") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error in file operation"), 404, header
 
@@ -468,7 +446,7 @@ def chmod():
             header = {"X-Invalid-Path": "{path} is an invalid path".format(path=path)}
             return jsonify(description="Error in chmod operation"), 400, header
 
-        if in_str(error_str, "not permitted"):
+        if in_str(error_str, "not permitted") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error in chmod operation"), 400, header
 
@@ -559,7 +537,7 @@ def chown():
             header={"X-Invalid-Path":"{path} is an invalid path".format(path=path)}
             return jsonify(description="Error in chown operation"), 400, header
 
-        if in_str(error_str,"not permitted"):
+        if in_str(error_str,"not permitted") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error in chown operation"), 400, header
 
@@ -654,7 +632,7 @@ def list_directory():
             header={"X-Invalid-Path":"{path} is an invalid path".format(path=path)}
             return jsonify(description="Error listing contents of path"), 400, header
 
-        if in_str(error_str,"cannot open"):
+        if in_str(error_str,"cannot open") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error listing contents of path"), 400, header
 
@@ -801,7 +779,7 @@ def make_directory():
             header={"X-Invalid-Path":"{path} is an invalid path".format(path=path)}
             return jsonify(description="Error creating directory"), 400, header
 
-        if in_str(error_str,"Permission denied"):
+        if in_str(error_str,"Permission denied") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error creating directory"), 400, header
 
@@ -888,7 +866,7 @@ def rename():
                 return jsonify(description="Error on rename operation"), 400, header
 
         # permission denied
-        if in_str(error_str,"Permission denied"):
+        if in_str(error_str,"Permission denied") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
             return jsonify(description="Error on rename operation"), 400, header
 
@@ -990,7 +968,7 @@ def common_operation(request, command, method):
                 return jsonify(description="Error on " + command + " operation"), 400, header
 
         # permission denied
-        if in_str(error_str,"Permission denied"):
+        if in_str(error_str,"Permission denied") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
             return jsonify(description="Error on " + command + " operation"), 400, header
 
@@ -1068,7 +1046,7 @@ def rm():
                 return jsonify(description="Error on delete operation"), 400, header
 
         # permission denied
-        if in_str(error_str,"Permission denied"):
+        if in_str(error_str,"Permission denied") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Error on delete operation"), 400, header
 
@@ -1146,7 +1124,7 @@ def symlink():
             return jsonify(description="Failed to create symlink"), 400, header
 
         # permission denied
-        if in_str(error_str,"Permission denied"):
+        if in_str(error_str,"Permission denied") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
             return jsonify(description="Failed to create symlink"), 400, header
 
@@ -1225,7 +1203,7 @@ def download():
         return jsonify(description="Failed to download file"), 400, header
 
     if retval["error"] != 0:
-        if in_str(retval["msg"],"Permission"):
+        if in_str(retval["msg"],"Permission") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
             return jsonify(description="Failed to download file"), 400, header
         else:
@@ -1325,7 +1303,7 @@ def upload():
         return jsonify(description="Failed to upload file"), 400, header
 
     if retval["error"] != 0:
-        if in_str(retval["msg"],"Permission"):
+        if in_str(retval["msg"],"Permission") or in_str(retval["msg"],"OPENSSH"):
             header = {"X-Permission-Denied": "User does not have permissions to access machine or paths"}
             return jsonify(description="Failed to upload file"), 400, header
         else:


### PR DESCRIPTION
This fix detects when an SSH certificate is rejected by SSH server on the target system and change the error message (`encountered RSA key, expected OPENSSH key`) for a standard error message.
 - In `utilities` and `storage` the header `X-Permission-Denied` is set.
- In `compute` (since the execution happens in the "background") the task output is updated with the same message `"User does not have permissions to access machine"`.