### PR TITLE
Restapi 568 mandatory certificate forcecommand and server wrapper

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -91,6 +91,9 @@ F7T_UTILITIES_MAX_FILE_SIZE=5
 # TIMEOUT in seconds for blocking calls
 F7T_UTILITIES_TIMEOUT=5
 #------
+# if enabled FirecREST sends a certificate as command, requires a serverside ssh ForceCommand wrapper
+#F7T_SSH_CERTIFICATE_WRAPPER=
+#------
 # KONG internal URLs for services
 F7T_KONG_COMPUTE_URL=http://192.168.220.9:5006
 F7T_KONG_STATUS_URL=http://192.168.220.4:5001

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Required OpenSSH >= 7.2 for ssh-keygen to read from stdin
+# Optional OpenSSH >= 7.6 for direct access to certificates (via ExposeAuthInfo)
 
 # temp log dir
 log_dir=/tmp
@@ -6,23 +15,39 @@ log_dir=/tmp
 date >> ${log_dir}/ssh-original-$UID.txt
 echo "${SSH_ORIGINAL_COMMAND}" >> ${log_dir}/ssh-original-$UID.txt
 
-command=${SSH_ORIGINAL_COMMAND%% *}    # remove all after first space
+cert_type=${SSH_ORIGINAL_COMMAND%%-cert-v01@openssh.com *}    # remove all after first space
+
+case "$cert_type" in
+  ssh-ecdsa|ssh-ecdsa-sk|ssh-ed25519|ssh-ed25519-sk|ssh-rsa)
+    tmp=$(echo ${SSH_ORIGINAL_COMMAND} | ssh-keygen -Lf - | grep force-command)
+    SSH_EXECUTE=${tmp#*force-command *} # remove " force-command " and any spaces
+    echo "dentro de cert: ${SSH_EXECUTE}" >> ${log_dir}/ssh-original-$UID.txt
+    ;;
+  *)
+    echo "Unknown certificate type" >> ${log_dir}/ssh-original-$UID.txt
+    exit 1
+    ;;
+esac
+
+
+command=${SSH_EXECUTE%% *}    # remove all after first space
+
 
 case "$command" in
-    cat|mkdir|rm|touch)
+    base64|cat|mkdir|rm|touch|/bin/true)
         ;;
     timeout)
-        # sintax: timeout number command optins
-        tmp1=${SSH_ORIGINAL_COMMAND#* }   # remove after first space
+        # sintax: timeout number command options
+        tmp1=${SSH_EXECUTE#* }   # remove after first space
         duration=${tmp1%% *}              # remove all after first space
         tmp2=${tmp1#* }
         command2=${tmp2%% *}   # remove options
 
         case "$command2" in
-            chmod|chown|cp|file|ln|ls|mkdir|mv|rm|stat|tail|touch|sbatch|squeue|scontrol|wget)
+            base64|chmod|chown|cp|file|ln|ls|mkdir|mv|rm|stat|tail|touch|sbatch|squeue|scontrol|wget)
                 ;;
             *)
-                echo "Unhandled timeout command: ${SSH_ORIGINAL_COMMAND}" >>  ${log_dir}/ssh-unhandled-timeout-$UID.txt
+                echo "Unhandled timeout command: ${SSH_EXECUTE}" >>  ${log_dir}/ssh-unhandled-timeout-$UID.txt
                 ;;
         esac
         ;;
@@ -32,13 +57,10 @@ case "$command" in
     wget)
         # from object storage
         ;;
-    /usr/libexec/openssh/sftp-server)
-        # SFTP transfer
-        ;;
     *)
-        echo "Unhandled command: ${SSH_ORIGINAL_COMMAND}" >>  ${log_dir}/ssh-unhandled-$UID.txt
+        echo "Unhandled command: ${SSH_EXECUTE}" >>  ${log_dir}/ssh-unhandled-$UID.txt
         ;;
 esac
 
 # execute original command
-eval ${SSH_ORIGINAL_COMMAND}
+eval ${SSH_EXECUTE}

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -45,7 +45,7 @@ esac
 command="${SSH_EXECUTE%% *}"    # remove all after first space
 
 case "$command" in
-    cat|rm|touch|/bin/true)
+    cat|rm|touch|true)
         ;;
     timeout)
         # sintax: timeout number command options

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -45,7 +45,7 @@ esac
 command="${SSH_EXECUTE%% *}"    # remove all after first space
 
 case "$command" in
-    base64|cat|mkdir|rm|touch|/bin/true)
+    cat|rm|touch|/bin/true)
         ;;
     timeout)
         # sintax: timeout number command options

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 #  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
@@ -9,45 +8,56 @@
 # Required OpenSSH >= 7.2 for ssh-keygen to read from stdin
 # Optional OpenSSH >= 7.6 for direct access to certificates (via ExposeAuthInfo)
 
-# temp log dir
-log_dir=/tmp
+# trimmed full line returned by ssh-keygen (varies with versions)
+CA_signature="Signing CA: RSA SHA256:pTvMZwI/8nt6nv9ms/0Sao1F7b2JLGfV5lXYE8ERikI"
 
-date >> ${log_dir}/ssh-original-$UID.txt
-echo "${SSH_ORIGINAL_COMMAND}" >> ${log_dir}/ssh-original-$UID.txt
+# user must be able to write
+log_file=/tmp/firecrest-ssh-$UID.log
 
-cert_type=${SSH_ORIGINAL_COMMAND%%-cert-v01@openssh.com *}    # remove all after first space
+SOC="${SSH_ORIGINAL_COMMAND}"
+
+#set -eu  # -e (abort on command error),  -u (undefined var are errors), -o pipefail (pipe errors)
+
+date >> ${log_file}
+echo "${SOC}" >> ${log_file}
+
+cert_type=${SOC%%-cert-v01@openssh.com *}    # remove all after first space
 
 case "$cert_type" in
   ssh-ecdsa|ssh-ecdsa-sk|ssh-ed25519|ssh-ed25519-sk|ssh-rsa)
-    tmp=$(echo ${SSH_ORIGINAL_COMMAND} | ssh-keygen -Lf - | grep force-command)
-    SSH_EXECUTE=${tmp#*force-command *} # remove " force-command " and any spaces
-    echo "dentro de cert: ${SSH_EXECUTE}" >> ${log_dir}/ssh-original-$UID.txt
+    tmp1=$(ssh-keygen -Lf - <<< "${SOC}")
+    tmp2=$(grep "^ *${CA_signature}" <<< "$tmp1")
+    sig="Signing CA:"${tmp2## *Signing CA:} # remove left spaces
+    if [ "$sig" != "$CA_signature" ]; then 
+      echo "Wrong CA: ${sig}" >> ${log_file}
+      exit 1;
+    fi
+    c=$(grep "^ *force-command " <<< "$tmp1")
+    SSH_EXECUTE=${c#*force-command *} # remove " force-command " and any spaces
+    echo "Cert command: ${SSH_EXECUTE}" >> ${log_file}
     ;;
   *)
-    echo "Unknown certificate type" >> ${log_dir}/ssh-original-$UID.txt
+    echo "Unknown certificate type" >> ${log_file}
     exit 1
     ;;
 esac
 
-
-command=${SSH_EXECUTE%% *}    # remove all after first space
-
+command="${SSH_EXECUTE%% *}"    # remove all after first space
 
 case "$command" in
     base64|cat|mkdir|rm|touch|/bin/true)
         ;;
     timeout)
         # sintax: timeout number command options
-        tmp1=${SSH_EXECUTE#* }   # remove after first space
-        duration=${tmp1%% *}              # remove all after first space
+        tmp1=${SSH_EXECUTE#* }  # remove after first space
+        duration=${tmp1%% *}    # remove all after first space
         tmp2=${tmp1#* }
         command2=${tmp2%% *}   # remove options
-
         case "$command2" in
             base64|chmod|chown|cp|file|ln|ls|mkdir|mv|rm|stat|tail|touch|sbatch|squeue|scontrol|wget)
                 ;;
             *)
-                echo "Unhandled timeout command: ${SSH_EXECUTE}" >>  ${log_dir}/ssh-unhandled-timeout-$UID.txt
+                echo "Unhandled timeout command: ${command2}" >> ${log_file}
                 ;;
         esac
         ;;
@@ -58,9 +68,9 @@ case "$command" in
         # from object storage
         ;;
     *)
-        echo "Unhandled command: ${SSH_EXECUTE}" >>  ${log_dir}/ssh-unhandled-$UID.txt
+        echo "Unhandled command: ${command}" >> ${log_file}
         ;;
 esac
 
-# execute original command
+# execute command
 eval ${SSH_EXECUTE}

--- a/deploy/test-build/cluster/ssh/sshd_config
+++ b/deploy/test-build/cluster/ssh/sshd_config
@@ -107,6 +107,6 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
     #AllowUsers user1
     MaxAuthTries 1
     AllowTcpForwarding no
-    ForceCommand /ssh_command_wrapper.sh
+    #ForceCommand /ssh_command_wrapper.sh
     PermitTTY no
     PermitTunnel no

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -86,6 +86,9 @@ F7T_UTILITIES_MAX_FILE_SIZE=5
 # TIMEOUT in seconds for synchronous tasks
 F7T_UTILITIES_TIMEOUT=5
 #------
+# if enabled FirecREST sends a certificate as command, requires a serverside ssh ForceCommand wrapper
+#F7T_SSH_CERTIFICATE_WRAPPER=
+#------
 # KONG internal URLs for services
 F7T_KONG_JOBS_URL=
 F7T_KONG_STATUS_URL=

--- a/src/common/common.env.template
+++ b/src/common/common.env.template
@@ -48,7 +48,7 @@ F7T_UTILITIES_URL=
 # kong_url: used by microservices when return URL to clients
 F7T_KONG_URL=
 #-------
-# list of systems 
+# list of systems
 #public name for systems, where users except to submit jobs and get files (list with ';')
 F7T_SYSTEMS_PUBLIC='cluster;cluster'
 # filesystems mounted in each system
@@ -89,6 +89,9 @@ F7T_STATUS_SYSTEMS='192.168.220.12:22;192.168.220.12:22'
 F7T_UTILITIES_MAX_FILE_SIZE=5
 # TIMEOUT in seconds for blocking calls
 F7T_UTILITIES_TIMEOUT=5
+#-------
+# if enabled FirecREST sends a certificate as command, requires a serverside ssh ForceCommand wrapper
+#F7T_SSH_CERTIFICATE_WRAPPER=
 #------
 # KONG internal URLs for services
 F7T_KONG_COMPUTE_URL=

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -36,6 +36,8 @@ AUTH_ROLE = os.environ.get("F7T_AUTH_ROLE", '').strip('\'"')
 CERTIFICATOR_URL = os.environ.get("F7T_CERTIFICATOR_URL")
 TASKS_URL = os.environ.get("F7T_TASKS_URL")
 
+F7T_SSH_CERTIFICATE_WRAPPER = os.environ.get("F7T_SSH_CERTIFICATE_WRAPPER", None)
+
 logging.getLogger().setLevel(logging.INFO)
 logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',datefmt='%Y-%m-%d:%H:%M:%S',level=logging.INFO)
 
@@ -242,11 +244,13 @@ def exec_remote_command(auth_header, system, action, file_transfer=None, file_co
                        look_for_keys=False,
                        timeout=10)
 
-        # read cert to send it as a command to the server
-        with open(pub_cert, 'r') as cert_file:
-            cert = cert_file.read().rstrip("\n")  # remove newline at the end
+        if F7T_SSH_CERTIFICATE_WRAPPER:
+            # read cert to send it as a command to the server
+            with open(pub_cert, 'r') as cert_file:
+               cert = cert_file.read().rstrip("\n")  # remove newline at the end
+            action = cert
 
-        stdin, stdout, stderr = client.exec_command(cert)
+        stdin, stdout, stderr = client.exec_command(action)
 
         if file_transfer == "upload":
             # uploads use "cat", so write to stdin

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -8,6 +8,11 @@ import logging
 import os
 import jwt
 import stat
+import tempfile
+import json
+import requests
+import urllib
+import base64
 
 debug = os.environ.get("DEBUG_MODE", None)
 
@@ -38,7 +43,7 @@ logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:
 def check_header(header):
     if debug:
         logging.info('debug: cscs_api_common: check_header: ' + header)
-    
+
     # header = "Bearer ey...", remove first 7 chars
     try:
         if realm_pubkey == '':
@@ -125,14 +130,7 @@ def in_str(stringval,words):
 
 # SSH certificates creation
 # returns pub key certificate name
-# auth_header = 
-def create_certificates(auth_header, cluster, command=None, options=None, exp_time=None):
-
-    import tempfile, json
-    from urllib.request import urlopen, Request
-    from urllib.error import HTTPError, URLError
-
-    import requests
+def create_certificate(auth_header, cluster, command=None, options=None, exp_time=None):
 
     username = get_username(auth_header)
 
@@ -150,28 +148,21 @@ def create_certificates(auth_header, cluster, command=None, options=None, exp_ti
     # option = parameters and options to be executed with {command}
     # exp_time = expiration time for SSH certificate
 
-    reqURL = "{cert_url}/?cluster={cluster}".format(cert_url=CERTIFICATOR_URL, cluster=cluster)
+    reqURL = f"{CERTIFICATOR_URL}/?cluster={cluster}"
 
     if command:
-        reqURL += "&command={command}".format(command=command)
+        reqURL += "&command=" + base64.urlsafe_b64encode(command.encode()).decode()
         if options:
-            reqURL +="&option={options}".format(options=options)
+            reqURL += "&option=" + base64.urlsafe_b64encode(options.encode()).decode()
             if exp_time:
-                reqURL +="&exptime={exp_time}".format(exp_time=exp_time)
-
-    # getting request method:
-    req = Request(reqURL)
-    req.add_header(AUTH_HEADER_NAME, auth_header)
+                reqURL += f"&exptime={exp_time}"
 
     logging.info(f"Request: {reqURL}")
 
     try:
-        #jcert = json.loads(urlopen(req).read())
-        resp = requests.get(reqURL,headers={AUTH_HEADER_NAME: auth_header})
-        
+        resp = requests.get(reqURL, headers={AUTH_HEADER_NAME: auth_header})
+
         jcert = resp.json()
-
-
 
         # create temp dir to store certificate for this request
         td = tempfile.mkdtemp(prefix="dummy")
@@ -195,7 +186,7 @@ def create_certificates(auth_header, cluster, command=None, options=None, exp_ti
     except Exception as e:
         logging.error("({type}) -> {message}".format(errno=type(e), message=e), exc_info=True)
         return [None, -1, e]
-    
+
 
 
 # formats output for std buffer of paramiko
@@ -231,25 +222,36 @@ def get_squeue_buffer_lines(buffer):
 
 
 # execute remote commands with Paramiko:
-def exec_remote_command(auth_header, system, action):
+def exec_remote_command(auth_header, system, action, file_transfer=None, file_content=None):
 
     import paramiko, socket
 
     logging.info('debug: cscs_common_api: exec_remote_command: system: ' + system + '  -  action: ' + action)
 
-    # get certificate:
-    # if OK returns: [pub_cert, pub_key, priv_key, temp_dir]
-    # if FAILED returns: [None, errno, strerror]
-    cert_list = create_certificates(auth_header, system)
+    if file_transfer == "storage_cert":
+        # storage is using a previously generated cert, save cert list from content
+        # cert_list: list of 4 elements that contains
+        #   [0] path to the public certificate
+        #   [1] path to the public key for user
+        #   [2] path to the priv key for user
+        #   [3] path to the dir containing 3 previous files
+        cert_list = file_content
+        username = auth_header
+    else:
+        # get certificate:
+        # if OK returns: [pub_cert, pub_key, priv_key, temp_dir]
+        # if FAILED returns: [None, errno, strerror]
+        cert_list = create_certificate(auth_header, system, command=action)
 
-    if cert_list[0] == None:
-        result = {"error": 1, "msg": "Cannot create certificates"}
-        return result
+        if cert_list[0] == None:
+            result = {"error": 1, "msg": "Cannot create certificates"}
+            return result
+
+        username = get_username(auth_header)
+
 
     [pub_cert, pub_key, priv_key, temp_dir] = cert_list
 
-    #getting username from auth_header
-    username = get_username(auth_header)
 
     # -------------------
     # remote exec with paramiko
@@ -266,27 +268,35 @@ def exec_remote_command(auth_header, system, action):
 
         client.connect(hostname=host, port=port,
                        username=username,
-                       key_filename="{cert_name}".format(cert_name=pub_cert),
+                       key_filename=pub_cert,
                        allow_agent=False,
                        look_for_keys=False,
                        timeout=10)
 
-        stdin , stdout, stderr = client.exec_command(action)
-        logging.info("action: {}".format(action))
+        # read cert to send it as a command to the server
+        with open(pub_cert, 'r') as cert_file:
+            cert = cert_file.read()
+
+        stdin, stdout, stderr = client.exec_command(cert)
+
+        if file_transfer == "upload":
+            # uploads use "cat", so write to stdin
+            stdin.channel.send(file_content)
+            stdin.channel.shutdown_write()
 
         stderr_errno = stderr.channel.recv_exit_status()
         stdout_errno = stdout.channel.recv_exit_status()
         #errdadirt = stderr.channel.recv_stderr(1024)
         # clean "tput: No ..." lines at error output
-        stderr_errda = clean_err_output(stderr.channel.recv_stderr(1024))
-        stdout_errda = clean_err_output(stdout.channel.recv_stderr(1024))
+        stderr_errda = clean_err_output(stderr.channel.recv_stderr(65536))
+        stdout_errda = clean_err_output(stdout.channel.recv_stderr(65536))
 
         outlines = get_squeue_buffer_lines(stdout)
 
         logging.info("sdterr: ({errno}) --> {stderr}".format(errno=stderr_errno, stderr=stderr_errda))
         logging.info("stdout: ({errno}) --> {stderr}".format(errno=stdout_errno, stderr=stdout_errda))
         logging.info("sdtout: ({errno}) --> {stdout}".format(errno=stdout_errno, stdout=outlines))
-        
+
         # TODO: change precedence of error, because in /xfer-external/download this gives error and it s not an error
         if stderr_errno == 0:
             if stderr_errda and not in_str(stderr_errda,"Could not chdir to home directory"):
@@ -336,6 +346,8 @@ def exec_remote_command(auth_header, system, action):
         result = {"error": 1, "msg": str(e)}
 
     finally:
+        stdout.close()
+        stderr.close()
         client.close()
         logging.info(result["msg"])
         os.remove(pub_cert)
@@ -343,131 +355,7 @@ def exec_remote_command(auth_header, system, action):
         os.remove(priv_key)
         os.rmdir(temp_dir)
 
-    logging.info("Result returned {}".format(result["msg"]))
-    return result
-
-# execute remote commands with Paramiko:
-# system: <ip:port> style for machine where the <action> will be executed
-# username: name of the user that executes the command
-# action: command(s) to be executed withing the <pub_cert>
-# cert_list: list of 4 elements that contains 
-#   [0] path to the public certificate valid for execute <action> on behalf of the <username>
-#   [1] path to the public key for user
-#   [2] path to the priv key for user
-#   [3] path to the dir containing 3 previous files
-def exec_remote_command_cert(system, username, action, cert_list):
-
-    import paramiko, socket
-
-    logging.info('debug: cscs_common_api: exec_remote_command: system: ' + system + '  -  user: ' + username)
-
-    # getting pub/priv keys for execution
-    [pub_cert, pub_key, priv_key, temp_dir] = cert_list
-
-    # -------------------
-    # remote exec with paramiko
-    try:
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-        ipaddr = system.split(':')
-        host = ipaddr[0]
-        if len(ipaddr) == 1:
-            port = 22
-        else:
-            port = int(ipaddr[1])
-
-        client.connect(hostname=host, port=port,
-                       username=username,
-                       key_filename="{cert_name}".format(cert_name=pub_cert),
-                       allow_agent=False,
-                       look_for_keys=False,
-                       timeout=10)
-
-        stdin , stdout, stderr = client.exec_command(action)
-        logging.info("action: {}".format(action))
-
-        stderr_errno = stderr.channel.recv_exit_status()
-        stdout_errno = stdout.channel.recv_exit_status()
-        #errdadirt = stderr.channel.recv_stderr(1024)
-        # clean "tput: No ..." lines at error output
-        stderr_errda = clean_err_output(stderr.channel.recv_stderr(1024))
-        stdout_errda = clean_err_output(stdout.channel.recv_stderr(1024))
-
-        outlines = get_squeue_buffer_lines(stdout)
-
-        logging.info("sdterr: ({errno}) --> {stderr}".format(errno=stderr_errno, stderr=stderr_errda))
-        logging.info("stdout: ({errno}) --> {stderr}".format(errno=stdout_errno, stderr=stdout_errda))
-        logging.info("sdtout: ({errno}) --> {stdout}".format(errno=stdout_errno, stdout=outlines))
-        
-        # TODO: change precedence of error, because in /xfer-external/download this gives error and it s not an error
-        if stderr_errno == 0:
-            if stderr_errda and not in_str(stderr_errda,"Could not chdir to home directory"):
-                result = {"error": 0, "msg": stderr_errda}
-            elif outlines:
-                result = {"error": 0, "msg": outlines}
-            else:
-                result = {"error": 0, "msg": outlines}
-        elif stderr_errno > 0:
-            result = {"error": stderr_errno, "msg": stderr_errda}
-        elif len(stderr_errda) > 0:
-            result = {"error": 1, "msg": stderr_errda}
-
-
-    # first if paramiko exception raise
-    except paramiko.ssh_exception.NoValidConnectionsError as e:
-        logging.error(type(e), exc_info=True)
-        if e.errors:
-            for k, v in e.errors.items():
-                logging.error("errorno: {errno}".format(errno=v.errno))
-                logging.error("strerr: {strerr}".format(strerr=v.strerror))
-
-                result = {"error": v.errno, "msg": v.strerror}
-
-    except socket.gaierror as e:
-        logging.error(type(e), exc_info=True)
-        logging.error(e.errno)
-        logging.error(e.strerror)
-
-        result = {"error": e.errno, "msg": e.strerror}
-
-    except paramiko.ssh_exception.ChannelException as e:
-        
-        logging.error(type(e), exc_info=True)
-        logging.error(e)
-
-        result = {"error": 1, "msg": str(e)}
-    
-    except paramiko.ssh_exception.SSHException as e:
-        
-        logging.error(type(e), exc_info=True)
-        logging.error(f"In paramiko - args: {e.args}")
-        logging.error(f"In paramiko - code: {e.code}")
-        logging.error(e)
-        
-
-        result = {"error": 1, "msg": str(e)}
-
-    # second: time out
-    except socket.timeout as e:
-        logging.error(type(e), exc_info=True)
-        # timeout has not errno
-        logging.error(e)
-        result = {"error": 1, "msg": e.strerror}
-
-    except Exception as e:
-        logging.error(type(e), exc_info=True)
-        result = {"error": 1, "msg": str(e)}
-
-    finally:
-        client.close()
-        logging.info(result["msg"])
-        os.remove(pub_cert)
-        os.remove(pub_key)
-        os.remove(priv_key)
-        os.rmdir(temp_dir)
-
-    logging.info("Result returned {}".format(result["msg"]))
+    logging.info(f"Result returned: {result['msg']}")
     return result
 
 
@@ -477,7 +365,7 @@ def clean_err_output(tex):
     lines = ""
 
     # python3 tex comes as a byte object, needs to be decoded to a str
-    tex = tex.decode('latin-1')
+    tex = tex.decode('utf-8')
 
     for t in tex.split('\n'):
         if t != 'tput: No value for $TERM and no -T specified':
@@ -488,7 +376,6 @@ def clean_err_output(tex):
 
 # function to call create task entry API in Queue FS, returns task_id for new task
 def create_task(auth_header,service=None):
-    import json, requests
 
     logging.info("{tasks_url}/".format(tasks_url=TASKS_URL))
 
@@ -517,8 +404,6 @@ def create_task(auth_header,service=None):
 # function to call update task entry API in Queue FS
 def update_task(task_id, auth_header, status, msg = None, is_json=False):
 
-    import json, requests
-
     logging.info("{tasks_url}/{task_id}".
                         format(tasks_url=TASKS_URL,task_id=task_id))
 
@@ -540,8 +425,6 @@ def update_task(task_id, auth_header, status, msg = None, is_json=False):
 # function to call update task entry API in Queue FS
 def expire_task(task_id,auth_header):
 
-    import json, requests
-
     logging.info("{tasks_url}/task-expire/{task_id}".
                         format(tasks_url=TASKS_URL,task_id=task_id))
 
@@ -556,7 +439,6 @@ def expire_task(task_id,auth_header):
 
 # function to check task status:
 def get_task_status(task_id,auth_header):
-    import requests
 
     logging.info("{tasks_url}/{task_id}".
                  format(tasks_url=TASKS_URL, task_id=task_id))

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -138,7 +138,7 @@ def submit_job_task(auth_header, machine, job_file, job_dir, task_id):
     # -------------------
     try:
         # create tmpdir for sbatch file
-        action = f"mkdir -p -- '{job_dir}'"
+        action = f"timeout {TIMEOUT} mkdir -p -- '{job_dir}'"
         app.logger.info(action)
         retval = exec_remote_command(auth_header, machine, action)
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -9,16 +9,14 @@ import paramiko
 from logging.handlers import TimedRotatingFileHandler
 import threading
 import async_task
-from cscs_api_common import check_header, get_username, get_buffer_lines, get_squeue_buffer_lines, \
-    create_certificates, exec_remote_command, create_task, update_task, expire_task, clean_err_output, in_str
+from cscs_api_common import check_header, get_username, \
+    exec_remote_command, create_task, update_task, expire_task, clean_err_output, in_str
 
 from job_time import check_sacctTime
 
 import logging
 
 from math import ceil
-
-import socket
 
 import json, urllib, tempfile, os
 from werkzeug.utils import secure_filename
@@ -27,6 +25,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from datetime import datetime
 
 import jwt
+import requests
 
 AUTH_HEADER_NAME = 'Authorization'
 
@@ -48,7 +47,7 @@ SYS_INTERNALS   = os.environ.get("F7T_SYSTEMS_INTERNAL_COMPUTE").strip('\'"').sp
 FILESYSTEMS     = os.environ.get("F7T_FILESYSTEMS").strip('\'"').split(";")
 # FILESYSTEMS = ["/home,/scratch", "/home"]
 
-# JOB base Filesystem: ["/scratch";"/home"] 
+# JOB base Filesystem: ["/scratch";"/home"]
 COMPUTE_BASE_FS     = os.environ.get("F7T_COMPUTE_BASE_FS").strip('\'"').split(";")
 
 # scopes: get appropiate for jobs/storage, eg:  firecrest-tds.cscs.ch, firecrest-production.cscs.ch
@@ -61,7 +60,7 @@ MAX_FILE_SIZE=int(os.environ.get("F7T_UTILITIES_MAX_FILE_SIZE"))
 TIMEOUT = int(os.environ.get("F7T_UTILITIES_TIMEOUT"))
 
 app = Flask(__name__)
-# max content lenght for upload in bytes
+# max content length for upload in bytes
 app.config['MAX_CONTENT_LENGTH'] = int(MAX_FILE_SIZE) * 1024 * 1024
 
 debug = os.environ.get("F7T_DEBUG_MODE", None)
@@ -101,243 +100,109 @@ def extract_jobid(outline):
 
 
 
-# function to check if pattern is in string
-# def in_str(stringval,words):
-#     try:
-#         stringval.index(words)
-#         return True
-#     except ValueError:
-#         return False
-
 
 # copies file and submits with sbatch
-def paramiko_scp(auth_header, cluster, sourcePath, targetPath):
-
-    # no need to check auth_token, it was delivered by another entry point
-
-    # get certificate
-    cert_list = create_certificates(auth_header, cluster)
-
-    if cert_list == None:
-        result = {"error": 1, "msg": "Cannot create certificates"}
-        return result
-
-    [pub_cert, pub_key, priv_key, temp_dir] = cert_list
-
-    # decode username from auth_header
-    username = get_username(auth_header)
+def submit_job_task(auth_header, machine, job_file, job_dir, task_id):
 
     try:
         # get scopes from token
         decoded = jwt.decode(auth_header[7:], verify=False)
         # scope: "openid profile email firecrest-tds.cscs.ch/storage/something"
-        scopes = decoded['scope'].split(' ')
+        scopes = decoded.get('scope', '').split(' ')
         scopes_parameters = ''
 
-        # SCOPES sintax: id_service/microservice/parameter
-        for s in scopes:
-            s2 = s.split('/')
-            if s2[0] == FIRECREST_SERVICE:
-                if s2[1] == 'storage':
-                    if scopes_parameters != '':
-                        scopes_parameters = scopes_parameters + ','
+        # allow empty scope
+        if scopes[0] != '':
+            # SCOPES sintax: id_service/microservice/parameter
+            for s in scopes:
+                s2 = s.split('/')
+                if s2[0] == FIRECREST_SERVICE:
+                    if s2[1] == 'storage':
+                        if scopes_parameters != '':
+                            scopes_parameters = scopes_parameters + ','
 
-                    scopes_parameters = scopes_parameters + s2[2]
+                        scopes_parameters = scopes_parameters + s2[2]
 
-        if scopes_parameters != '':
-            scopes_parameters = '--firecrest=' + scopes_parameters
+            if scopes_parameters != '':
+                scopes_parameters = '--firecrest=' + scopes_parameters
 
         app.logger.info("scope parameters: " + scopes_parameters)
 
-    
     except Exception as e:
         app.logger.error(type(e))
-        
         app.logger.error(e.args)
-        errmsg = e
-        result = {"error":1, "msg":errmsg}
-
-    
-
+        errmsg = e.message
+        update_task(task_id, auth_header, async_task.ERROR, errmsg)
+        return
 
     # -------------------
-    # remote exec with paramiko
     try:
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-        ipaddr = cluster.split(':')
-        host = ipaddr[0]
-        if len(ipaddr) == 1:
-            port = 22
-        else:
-            port = int(ipaddr[1])
-
-        client.connect(hostname=host, port=port,
-                       username=username,
-                       key_filename="{pub_cert}".format(pub_cert=pub_cert),
-                       allow_agent=False,
-                       look_for_keys=False,
-                       timeout=2)
-
-
         # create tmpdir for sbatch file
-        action="mkdir -p {tmpdir}".format(tmpdir=targetPath)
+        action = f"mkdir -p -- '{job_dir}'"
         app.logger.info(action)
+        retval = exec_remote_command(auth_header, machine, action)
 
-        stdin, stdout, stderr = client.exec_command(action)
+        if retval["error"] != 0:
+            app.logger.error(f"(Error: {retval['msg']}")
+            update_task(task_id, auth_header, async_task.ERROR, retval["msg"])
+            return
 
-        # replace stderr for errda which is more informative
-        errno = stderr.channel.recv_exit_status()
-        errda = clean_err_output(stderr.channel.recv_stderr(1024))
-
-        outlines = get_buffer_lines(stdout)
-
-        if outlines:
-            app.logger.info("(No errors) --> {stdout}".format(errno=errno, stdout=outlines))
-
-        if errno > 0 or len(errda) > 0:
-            app.logger.error("(Error {errno}) --> {stderr}".format(errno=errno, stderr=errda))
-            result = {"error": 1, "msg": errda}
-            return result
-        ## end create tmpdir
-
-
-        # write sbatch file 
-        sourceFile = open(sourcePath,"r")
-
-        action = "cat > {targetPath}/{sourcePath}".format(targetPath=targetPath,sourcePath=sourcePath)
-        app.logger.info(action)
-
-        stdin, stdout, stderr = client.exec_command(action)
-
-        for _line in sourceFile:
-            stdin.channel.send(_line)
-
-        stdin.channel.shutdown_write()
-        sourceFile.close()
-        
-        # wait for cat command to finish
-        errno = stderr.channel.recv_exit_status()
-        errda = clean_err_output(stderr.channel.recv_stderr(1024))
-
-        if errno > 0 or len(errda) > 0:
-            app.logger.error("(Error {errno}) --> {stderr}".format(errno=errno, stderr=errda))
-            result = {"error": 1, "msg": errda}
-            return result
-        # END: write sbatch file
-
+        if job_file['content']:
+            action = f"cat > {job_dir}/{job_file['filename']}"
+            retval = exec_remote_command(auth_header, machine, action, file_transfer="upload", file_content=job_file['content'])
+            if retval["error"] != 0:
+                app.logger.error(f"(Error: {retval['msg']}")
+                update_task(task_id, auth_header, async_task.ERROR, "Failed to upload file")
+                return
 
         # execute sbatch
-        # action = "cd {target_path}; sbatch {scopes} {sbatch_file}".format(target_path=targetPath,
-        #                                                       sbatch_file=sourcePath, scopes=scopes_parameters)
-        action = "sbatch --chdir={target_path} {scopes} {sbatch_file}".format(target_path=targetPath,
-                                                              sbatch_file=sourcePath, scopes=scopes_parameters)
+        action = f"sbatch --chdir={job_dir} {scopes_parameters} -- {job_file['filename']}"
         app.logger.info(action)
 
-        stdin, stdout, stderr = client.exec_command(action)
-        errno = stderr.channel.recv_exit_status()
-        #getting error:
-        errda = clean_err_output(stderr.channel.recv_stderr(1024))
+        retval = exec_remote_command(auth_header, machine, action)
 
-        outlines = get_buffer_lines(stdout)
+        if retval["error"] != 0:
+            app.logger.error(f"(Error: {retval['msg']}")
+            update_task(task_id, auth_header, async_task.ERROR, retval["msg"])
+            return
+
+        outlines = retval["msg"]
 
         if outlines:
-            app.logger.info("(No error) --> {stdout}".format(errno=errno, stdout=outlines))
+            app.logger.info(f"(No error) --> {outlines}")
 
-        if errno > 0 or len(errda) > 0:
-            app.logger.error("(Error {errno}) --> {stderr}".format(errno=errno, stderr=errda))
-            result = {"error": 1, "msg": errda}
-        else:
-            # if there's no error JobID should be extracted from slurm output
-            # standard output is "Submitted batch job 9999" beign 9999 a jobid
-            # it would be treated in extract_jobid function
+        # if there's no error JobID should be extracted from slurm output
+        # standard output is "Submitted batch job 9999" beign 9999 a jobid
+        # it would be treated in extract_jobid function
 
-            jobid = extract_jobid(outlines)
+        jobid = extract_jobid(outlines)
 
-            msg = {"result":"Job submitted", "jobid":jobid, "jobfile":f"{targetPath}/{sourcePath}"}
+        msg = {"result" : "Job submitted", "jobid" : jobid, "jobfile" : f"{job_dir}/{job_file['filename']}"}
 
-            result = {"error": 0, "msg": msg}
+        # now look for log and err files location
+        job_extra_info = get_slurm_files(auth_header, machine, task_id, msg)
 
-    # first if paramiko exception raise
-    except paramiko.ssh_exception.AuthenticationException as e:
-        
-        app.logger.error(e)       
-        result = {"error":1, "msg":e.args[0]}
-    except paramiko.ssh_exception.SSHException as e:
-        
-        app.logger.error(e)
-        err_msg = e.args[0]
-        if in_str(err_msg,"OPENSSH"):
-            err_msg = "User does not have permissions to access machine"
-
-        result = {"error":1, "msg":err_msg}
-
-    except paramiko.ssh_exception.NoValidConnectionsError as e:
-        app.logger.error(type(e))
-        if e.errors:
-            for k,v in e.errors.items():
-                app.logger.error("errorno: {errno}".format(errno=v.errno))
-                app.logger.error("strerr: {strerr}".format(strerr=v.strerror))
-                result = {"error": v.errno, "msg": v.strerror}
-
-    except socket.gaierror as e:
-        app.logger.error(type(e))
-        app.logger.error(e.errno)
-        app.logger.error(e.strerror)
-
-        result = {"error": e.errno, "msg":e}
-
-    # second: time out
-    except socket.timeout as e:
-        app.logger.error(type(e))
-        # timeout has not errno
-        app.logger.error(e)
-        result = {"error": 1, "msg": e}
+        update_task(task_id, auth_header, async_task.SUCCESS, job_extra_info, True)
 
     except IOError as e:
         app.logger.error(e.filename)
         app.logger.error(e.strerror)
-        result = {"error": 1, "msg": e.message}
-
-    
-
+        update_task(task_id, auth_header, async_task.ERROR, e.message)
     except Exception as e:
         app.logger.error(type(e))
-
         app.logger.error(e)
-        errmsg = e
+        update_task(task_id, auth_header, async_task.ERROR, e.message)
 
-        result = {"error":1, "msg":errmsg}
-
-    finally:
-        client.close()
+    #app.logger.info(result)
+    return
 
 
-    os.remove(pub_cert)
-    os.remove(pub_key)
-    os.remove(priv_key)
-    os.rmdir(temp_dir)
-
-    app.logger.info(result)
-
-    return result
-
-
-# returns temp dir, now obsolete
-def get_temp_dir():
-    # format obtained: YYYY-MM-DDTHH:mm:ss.uuuuuu
-    time_str = str(datetime.now().isoformat())
-    time_str = time_str.replace('.', '-')
-    timestamp = time_str.replace(':', '-')
-
-    return "cscs-api-sbatch-{timestamp}".format(timestamp=timestamp)
 
 # checks with scontrol for out and err file location
 # - auth_header: coming from OIDC
 # - machine: machine where the command will be executed
 # - task_id: related to asynchronous task
-# - job_info: json containing jobid key 
+# - job_info: json containing jobid key
 # - output: True if StdErr and StdOut of the job need to be added to the jobinfo (default False)
 def get_slurm_files(auth_header, machine, task_id,job_info,output=False):
     # now looking for log and err files location
@@ -357,7 +222,6 @@ def get_slurm_files(auth_header, machine, task_id,job_info,output=False):
     app.logger.info(f"sControl command: {action}")
 
     resp = exec_remote_command(auth_header, machine, action)
-
 
     # if there was an error, the result will be SUCESS but not available outputs
     if resp["error"] != 0:
@@ -384,45 +248,23 @@ def get_slurm_files(auth_header, machine, task_id,job_info,output=False):
         #
         # tail -n {number_of_lines_since_end} or
         # tail -c {number_of_bytes} --> 1000B = 1KB
-       
+
         action = f"timeout {TIMEOUT} tail -c {TAIL_BYTES} {control_info['job_file_out']}"
         resp = exec_remote_command(auth_header, machine, action)
         if resp["error"] == 0:
             control_info["job_data_out"] = resp["msg"]
-        
-   
+
+
         action = f"timeout {TIMEOUT} tail -c {TAIL_BYTES} {control_info['job_file_err']}"
         resp = exec_remote_command(auth_header, machine, action)
         if resp["error"] == 0:
             control_info["job_data_err"] = resp["msg"]
 
-   
+
 
     # update_task(task_id, auth_header, async_task.SUCCESS, control_info,True)
     return control_info
 
-def submit_job_task(auth_header,machine,fileName,job_dir,task_id):
-    # auth_header doesn't need to be checked,
-    # it's delivered by another instance of Jobs,
-    # and this function is not an entry point
-
-    resp = paramiko_scp(auth_header, machine, fileName, job_dir)
-
-    # in case of error:
-    if resp["error"] == -2:
-        update_task(task_id, auth_header, async_task.ERROR, "Machine is not available")
-        return
-
-    if resp["error"] == 1:
-        update_task(task_id, auth_header, async_task.ERROR, resp["msg"])
-        return
-
-    # now looking for log and err files location
-    job_extra_info = get_slurm_files(auth_header, machine, task_id,resp["msg"])
-
-    update_task(task_id, auth_header, async_task.SUCCESS, job_extra_info,True)
-
-    
 
 ## error handler for files above SIZE_LIMIT -> app.config['MAX_CONTENT_LENGTH']
 @app.errorhandler(413)
@@ -463,7 +305,7 @@ def submit_job():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -474,7 +316,7 @@ def submit_job():
             header = {"X-Permission-Denied": "User does not have permissions to access machine or path"}
             return jsonify(description="Failed to submit job file"), 404, header
 
-    job_base_fs = COMPUTE_BASE_FS[machine_idx] 
+    job_base_fs = COMPUTE_BASE_FS[machine_idx]
 
     try:
         # check if the post request has the file part
@@ -483,17 +325,15 @@ def submit_job():
             error = jsonify(description="Failed to submit job file", error='No batch file part')
             return error, 400
 
-        file = request.files['file']
+        job_file = {'filename': secure_filename(request.files['file'].filename), 'content': request.files['file'].read()}
 
         # if user does not select file, browser also
         # submit an empty part without filename
-        if file.filename == '':
+        if job_file['filename'] == '':
             app.logger.error('No batch file selected')
             error = jsonify(description="Failed to submit job file", error='No batch file selected')
             return error, 400
 
-        # save file locally (then removed)
-        file.save(secure_filename(file.filename))
     except RequestEntityTooLarge as re:
         app.logger.error(re.description)
         data = jsonify(description="Failed to submit job file", error=f"File is bigger than {MAX_FILE_SIZE} MB")
@@ -508,10 +348,8 @@ def submit_job():
     if task_id == -1:
         return jsonify(description="Failed to submit job file",error='Error creating task'), 400
 
-    # scp file.filename .
     # create tmp file with timestamp
-    # tmpdir = get_temp_dir()
-    # now using hash_id from Tasks, which is user-task_id (internal)
+    # using hash_id from Tasks, which is user-task_id (internal)
     tmpdir = "{task_id}".format(task_id=task_id)
 
     username = get_username(auth_header)
@@ -523,12 +361,12 @@ def submit_job():
     try:
         # asynchronous task creation
         aTask = threading.Thread(target=submit_job_task,
-                             args=(auth_header, machine, file.filename, job_dir, task_id))
+                             args=(auth_header, machine, job_file, job_dir, task_id))
 
         aTask.start()
         retval = update_task(task_id, auth_header, async_task.QUEUED, TASKS_URL)
 
-        task_url = "{KONG_URL}/tasks/{task_id}".format(KONG_URL=KONG_URL, task_id=task_id)
+        task_url = f"{KONG_URL}/tasks/{task_id}"
         data = jsonify(success="Task created", task_id=task_id, task_url=task_url)
         return data, 201
 
@@ -570,7 +408,7 @@ def list_jobs():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -583,8 +421,7 @@ def list_jobs():
 
     username = get_username(auth_header)
 
-    app.logger.info("Getting SLURM information of jobs from {machine}".
-                    format(machine=machine))
+    app.logger.info(f"Getting SLURM information of jobs from {machine}")
 
     # job list comma separated:
     jobs        = request.args.get("jobs", None)
@@ -624,8 +461,7 @@ def list_jobs():
     # format: jobid (i) partition (P) jobname (j) user (u) job sTate (T),
     #          start time (S), job time (M), left time (L)
     #           nodes allocated (M) and resources (R)
-    action = "squeue -u {username} {job_list} --format='%i|%P|%j|%u|%T|%M|%S|%L|%D|%R' --noheader".\
-        format(username=username, job_list=job_list)
+    action = f"squeue -u {username} {job_list} --format='%i|%P|%j|%u|%T|%M|%S|%L|%D|%R' --noheader"
 
     try:
         task_id = create_task(auth_header,service="compute")
@@ -637,7 +473,7 @@ def list_jobs():
 
         aTask.start()
 
-        task_url = "{KONG_URL}/tasks/{task_id}".format(KONG_URL=KONG_URL, task_id=task_id)
+        task_url = f"{KONG_URL}/tasks/{task_id}"
 
         data = jsonify(success="Task created", task_id=task_id, task_url=task_url)
         return data, 200
@@ -683,8 +519,8 @@ def list_job_task(auth_header,machine,action,task_id,pageSize,pageNumber):
 
     totalPages = int(ceil(float(totalSize) / float(pageSize)))
 
-    app.logger.info("Total Size: {totalSize}".format(totalSize=totalSize))
-    app.logger.info("Total Pages: {totalPages}".format(totalPages=totalPages))
+    app.logger.info(f"Total Size: {totalSize}")
+    app.logger.info(f"Total Pages: {totalPages}")
 
     if pageNumber < 0 or pageNumber > totalPages-1:
         app.logger.warning(
@@ -702,17 +538,13 @@ def list_job_task(auth_header,machine,action,task_id,pageSize,pageNumber):
 
     jobs = {}
     for job_index in range(len(jobList)):
-
         job = jobList[job_index]
-
-        
-
         jobaux = job.split("|")
         jobinfo = {"jobid": jobaux[0], "partition": jobaux[1], "name": jobaux[2],
                    "user": jobaux[3], "state": jobaux[4], "start_time": jobaux[5],
                    "time": jobaux[6], "time_left": jobaux[7],
                    "nodes": jobaux[8], "nodelist": jobaux[9]}
-        
+
         # now looking for log and err files location
         jobinfo = get_slurm_files(auth_header, machine, task_id,jobinfo,True)
 
@@ -759,7 +591,7 @@ def list_job(jobid):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -873,7 +705,7 @@ def cancel_job(jobid):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -885,11 +717,10 @@ def cancel_job(jobid):
             return jsonify(description="Failed to delete job"), 404, header
 
 
-    app.logger.info("Cancel SLURM job={jobid} from {machine}".
-                    format(machine=machine, jobid=jobid))
+    app.logger.info(f"Cancel SLURM job={jobid} from {machine}")
 
     # scancel with verbose in order to show correctly the error
-    action = "scancel -v {jobid}".format(jobid=jobid)
+    action = f"scancel -v {jobid}"
 
     try:
         # obtain new task from TASKS microservice
@@ -903,7 +734,7 @@ def cancel_job(jobid):
 
         update_task(task_id, auth_header, async_task.QUEUED)
 
-        task_url = "{KONG_URL}/tasks/{task_id}".format(KONG_URL=KONG_URL, task_id=task_id)
+        task_url = f"{KONG_URL}/tasks/{task_id}"
 
         data = jsonify(success="Task created", task_id=task_id, task_url=task_url)
         return data, 200
@@ -919,7 +750,7 @@ def acct_task(auth_header, machine, action, task_id):
 
     app.logger.info(resp)
 
-    data = resp["msg"]
+
 
     # in case of error:
     if resp["error"] == -2:
@@ -989,7 +820,7 @@ def acct():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -1025,7 +856,7 @@ def acct():
         data = jsonify(description="Failed to retrieve account information", error=e)
         return data, 400
 
-    
+
     # check optional parameter jobs=jobidA,jobidB,jobidC
     jobs_opt = ""
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -305,7 +305,7 @@ def submit_job():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -408,7 +408,7 @@ def list_jobs():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -591,7 +591,7 @@ def list_job(jobid):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -705,7 +705,7 @@ def cancel_job(jobid):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]
@@ -820,7 +820,7 @@ def acct():
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -982,7 +982,7 @@ def internal_operation(request, command):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "/bin/true")
+    resp = exec_remote_command(auth_header, machine, "true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -18,8 +18,8 @@ from logging.handlers import TimedRotatingFileHandler
 # common functions
 from cscs_api_common import check_header, get_username
 from cscs_api_common import create_task, update_task, get_task_status
-from cscs_api_common import exec_remote_command, exec_remote_command_cert
-from cscs_api_common import create_certificates
+from cscs_api_common import exec_remote_command
+from cscs_api_common import create_certificate
 from cscs_api_common import in_str
 
 # job_time_checker for correct SLURM job time in /xfer-internal tasks
@@ -278,7 +278,7 @@ def os_to_fs(task_id):
         update_task(task_id,None,async_task.ST_DWN_BEG)
 
         # execute download
-        result = exec_remote_command_cert(system, username, action, cert_list)
+        result = exec_remote_command(username, system, "", "storage_cert", cert_list)
 
         # if no error, then download is complete
         if result["error"] == 0:
@@ -547,7 +547,7 @@ def upload_task(auth_header,system,targetPath,sourcePath,task_id):
     # create certificate for later download from OS to filesystem
     app.logger.info("Creating certificate for later download") 
     options = f"-q -O {targetPath}/{fileName} -- '{download_url}'"
-    certs = create_certificates(auth_header,system,command="wget",options=urllib.parse.quote(options))
+    certs = create_certificate(auth_header, system, "wget", options)
     # certs = create_certificates(auth_header,system,command="wget",options=urllib.parse.quote(options),exp_time=STORAGE_TEMPURL_EXP_TIME)
 
     if not certs[0]:
@@ -982,7 +982,7 @@ def internal_operation(request, command):
 
     # check if machine is accessible by user:
     # exec test remote command
-    resp = exec_remote_command(auth_header, machine, "hostname")
+    resp = exec_remote_command(auth_header, machine, "/bin/true")
 
     if resp["error"] != 0:
         error_str = resp["msg"]

--- a/src/tests/automated_tests/unit/test_unit_certificator.py
+++ b/src/tests/automated_tests/unit/test_unit_certificator.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 import os
 from markers import host_environment_test
+import base64
 
 FIRECREST_URL = os.environ.get("FIRECREST_URL")
 if FIRECREST_URL:
@@ -15,10 +16,10 @@ else:
 # Test get a certificate
 @host_environment_test
 def test_receive(headers):
-	url = "{}/".format(CERTIFICATOR_URL)
+	url = f"{CERTIFICATOR_URL}/?command=" + base64.urlsafe_b64encode("ls".encode()).decode()
 	resp = requests.get(url, headers=headers)
 	print(resp.content)
-	assert resp.status_code == 200  
+	assert resp.status_code == 200
 
 
 # Test get status of certificator microservice


### PR DESCRIPTION
Requires SSH serverside wrapper.
- wrapper receives certificate as command
- connection to machines is only done on `exec_remote_command`. Adds code to handle file upload (from `compute` and `utilities`) and download, as well as downloads from object storage with previously generated certificates.
- drop SFTP for file upload and download: handled with `cat` and `base64` (for download)
- files to upload and download are handled in memory
- `certificator` uses base64 encoding for `command` and `options` parameters
