### PR TITLE
Restapi 569 compute to be able to select file in target machine filesytem for submission

### DIFF
--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -78,5 +78,13 @@ RUN /usr/libexec/mariadb-prepare-db-dir 2>/dev/null
 ADD cluster/ssh/ssh_command_wrapper.sh /ssh_command_wrapper.sh
 RUN chmod 555 /ssh_command_wrapper.sh
 
+# add sbatch scripts for testing purposes
+RUN mkdir /srv/f7t
+ADD cluster/test_sbatch.sh /srv/f7t/.
+ADD cluster/test_sbatch.sh /srv/f7t/test_sbatch_forbidden.sh
+RUN chmod 777 /srv/f7t
+RUN chmod 555 /srv/f7t/test_sbatch.sh
+RUN chmod 700 /srv/f7t/test_sbatch_forbidden.sh
+
 ENTRYPOINT ["/usr/bin/supervisord"]
 

--- a/deploy/test-build/cluster/test_sbatch.sh
+++ b/deploy/test-build/cluster/test_sbatch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#SBATCH --job-name=testsbatch
+#SBATCH --ntasks=1
+#SBATCH --tasks-per-node=1
+#SBATCH --output=testsbatch.output
+#SBATCH --error=testsbatch.error
+
+
+sleep 60s

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -845,7 +845,7 @@ paths:
               description: Command has finished with timeout signal
               schema:
                 type: string
-  '/compute/jobs':
+  '/compute/jobs/upload':
     parameters:
       - in: header
         name: X-Machine-Name
@@ -854,7 +854,7 @@ paths:
         schema:
           type: string
     post:
-      summary: Submit Job
+      summary: Submit Job by uploading a local sbatch file
       description: >-
         Non-blocking call. Submits a batch script to SLURM on the target system.
         The batch script is uploaded as a file to the microservice which then
@@ -907,6 +907,75 @@ paths:
               description: sbatch returned error
               schema:
                 type: integer
+  '/compute/jobs/path':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Submit Job by a given remote sbatch file
+      description: >-
+        Non-blocking call. Submits a batch script to SLURM on the target system.
+        The batch script is uploaded as a file to the microservice which then
+        stores it in a temporal directory in preparation to be submitted to the
+        workload manager. The operation returns the task id associated to the
+        Task microservice that will contain information of the SLURM job once
+        it is created.
+      tags:
+        - Compute
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: path to the SBATCH script file stored in {X-Machine-Name} machine to be submitted to SLURM
+              required:
+                - targetPath
+      responses:
+        '201':
+          description: Task for job creation queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-ok'
+        '400':
+          description: Failed to submit job file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: integer
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: integer
+            X-Permission-Denied:
+              description: User does not have permissions to access machine
+              schema:
+                type: integer
+            X-sbatch-error:
+              description: sbatch returned error
+              schema:
+                type: integer
+  '/compute/jobs':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
     get:
       summary: Retrieves information from all jobs
       description: Information about jobs on the SLURM scheduling queue. This call uses the `squeue` command.

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -594,9 +594,8 @@ def get_task_status(task_id,auth_header):
 # checks if {path} is a valid file (exists and user in {auth_header} has read permissions)
 def is_valid_file(path, auth_header, system):
 
-    # checks user accessibility to path using touch
-    # -r parameter is to not modify timestamp of the file (by modifiying for the same file's timestamp)
-    action = f"tail -c 1 -- {path}"
+    # checks user accessibility to path using head command with 0 bytes
+    action = f"head -c 1 -- {path}"
 
     retval = exec_remote_command(auth_header,system,action)
 

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -596,7 +596,7 @@ def is_valid_file(path, auth_header, system):
 
     # checks user accessibility to path using touch
     # -r parameter is to not modify timestamp of the file (by modifiying for the same file's timestamp)
-    action = f"touch -r {path} {path}"
+    action = f"tail -c 1 -- {path}"
 
     retval = exec_remote_command(auth_header,system,action)
 
@@ -621,18 +621,20 @@ def is_valid_file(path, auth_header, system):
         # permission denied
         if in_str(error_str,"Permission denied") or in_str(error_str,"OPENSSH"):
             return {"result":False, "headers":{"X-Permission-Denied": "User does not have permissions to access machine or path"}}
-            
+
+        if in_str(error_str, "directory"):
+            return {"result":False, "headers":{"X-A-Directory": "{path} is a directory".format(path=path)}}  
 
         return {"result":False, "headers":{"X-Error": retval["msg"]}}
 
     # checks using ls -ld of the path (-d is used for listing dir info not its content)
-    action = f"ls -ld {path}"
+    # action = f"ls -ld {path}"
 
-    retval = exec_remote_command(auth_header,system,action)
+    # retval = exec_remote_command(auth_header,system,action)
 
-    is_dir = retval["msg"][0]
-    if is_dir ==  "d":
-        return {"result":False, "headers":{"X-A-Directory": "{path} is a directory".format(path=path)}}
+    # is_dir = retval["msg"][0]
+    # if is_dir ==  "d":
+    #     return {"result":False, "headers":{"X-A-Directory": "{path} is a directory".format(path=path)}}
 
 
     return {"result":True}

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -508,12 +508,12 @@ def get_task_status(task_id,auth_header):
 
 
 # checks if {path} is a valid file (exists and user in {auth_header} has read permissions)
-def is_valid_file(path, auth_header, system):
+def is_valid_file(path, auth_header, system_name, system_addr):
 
     # checks user accessibility to path using head command with 0 bytes
     action = f"head -c 1 -- {path}"
 
-    retval = exec_remote_command(auth_header,system,action)
+    retval = exec_remote_command(auth_header,system_name, system_addr,action)
 
     logging.info(retval)
 
@@ -542,16 +542,6 @@ def is_valid_file(path, auth_header, system):
 
         return {"result":False, "headers":{"X-Error": retval["msg"]}}
 
-    # checks using ls -ld of the path (-d is used for listing dir info not its content)
-    # action = f"ls -ld {path}"
-
-    # retval = exec_remote_command(auth_header,system,action)
-
-    # is_dir = retval["msg"][0]
-    # if is_dir ==  "d":
-    #     return {"result":False, "headers":{"X-A-Directory": "{path} is a directory".format(path=path)}}
-
-
     return {"result":True}
 
 
@@ -559,7 +549,7 @@ def is_valid_file(path, auth_header, system):
 # checks if {path} is a valid directory
 # 'path' should exists and be accesible to the user (write permissions)
 #
-def is_valid_dir(path, auth_header, system):
+def is_valid_dir(path, auth_header, system_name, system_addr):
 
     # create an empty file for testing path accesibility
     # test file is a hidden file and has a timestamp in order to not overwrite other files created by user
@@ -575,7 +565,7 @@ def is_valid_dir(path, auth_header, system):
 
     action = f"touch -- {path}/{tempFileName}"
 
-    retval = exec_remote_command(auth_header,system,action)
+    retval = exec_remote_command(auth_header,system_name, system_addr,action)
 
     logging.info(retval)
 
@@ -604,7 +594,7 @@ def is_valid_dir(path, auth_header, system):
 
     # delete test file created
     action = f"rm -- {path}/{tempFileName}"
-    retval = exec_remote_command(auth_header,system,action)
+    retval = exec_remote_command(auth_header,system_name, system_addr,action)
 
 
     return {"result":True}

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -270,27 +270,6 @@ def get_slurm_files(auth_header, system_name, system_addr, task_id,job_info,outp
     # update_task(task_id, auth_header, async_task.SUCCESS, control_info,True)
     return control_info
 
-def submit_job_task(auth_header,machine,fileName,job_dir,task_id):
-    # auth_header doesn't need to be checked,
-    # it's delivered by another instance of Jobs,
-    # and this function is not an entry point
-
-    resp = paramiko_scp(auth_header, machine, fileName, job_dir)
-
-    # in case of error:
-    if resp["error"] == -2:
-        update_task(task_id, auth_header, async_task.ERROR, "Machine is not available")
-        return
-
-    if resp["error"] == 1:
-        update_task(task_id, auth_header, async_task.ERROR, resp["msg"])
-        return
-
-    # now looking for log and err files location
-    job_extra_info = get_slurm_files(auth_header, machine, task_id,resp["msg"])
-
-    update_task(task_id, auth_header, async_task.SUCCESS, job_extra_info,True)
-
 def submit_job_path_task(auth_header,system_name, system_addr,fileName,job_dir, task_id):
     
     try:
@@ -350,7 +329,7 @@ def submit_job_path_task(auth_header,system_name, system_addr,fileName,job_dir, 
 
     
     # now looking for log and err files location
-    job_extra_info = get_slurm_files(auth_header, machine, task_id,msg)
+    job_extra_info = get_slurm_files(auth_header, system_name, system_addr, task_id,msg)
 
     update_task(task_id, auth_header, async_task.SUCCESS, job_extra_info,True)
     
@@ -508,7 +487,7 @@ def submit_job_path():
 
     
     # checks if targetPath is a valid path for this user in this machine
-    check = is_valid_file(targetPath, auth_header, machine)
+    check = is_valid_file(targetPath, auth_header, system_name, system_addr)
 
     if not check["result"]:
         return jsonify(description="Failed to submit job"), 400, check["headers"]
@@ -712,7 +691,7 @@ def list_job_task(auth_header,system_name, system_addr,action,task_id,pageSize,p
                    "nodes": jobaux[8], "nodelist": jobaux[9]}
 
         # now looking for log and err files location
-        jobinfo = get_slurm_files(auth_header, machine, task_id,jobinfo,True)
+        jobinfo = get_slurm_files(auth_header, system_name, system_addr, task_id,jobinfo,True)
 
         # add jobinfo to the array
         jobs[str(job_index)]=jobinfo

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -342,7 +342,7 @@ def download_request():
         return data, 400
 
     # checks if sourcePath is a valid path
-    check = is_valid_file(sourcePath, auth_header, system)
+    check = is_valid_file(sourcePath, auth_header, system_name, system_addr)
 
 
     if not check["result"]:
@@ -514,7 +514,7 @@ def upload_request():
         return data, 400
 
     # checks if sourcePath is a valid path
-    check = is_valid_dir(targetPath, auth_header, system)
+    check = is_valid_dir(targetPath, auth_header, system_name, system_addr)
 
     if not check["result"]:
         return jsonify(description="sourcePath error"), 400, check["headers"]

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -21,6 +21,7 @@ from cscs_api_common import create_task, update_task, get_task_status
 from cscs_api_common import exec_remote_command, exec_remote_command_cert
 from cscs_api_common import create_certificates
 from cscs_api_common import in_str
+from cscs_api_common import is_valid_file, is_valid_dir
 
 # job_time_checker for correct SLURM job time in /xfer-internal tasks
 import job_time
@@ -101,111 +102,6 @@ debug = os.environ.get("F7T_DEBUG_MODE", None)
 
 
 app = Flask(__name__)
-
-# checks if path is valid for upload/download file process
-# 'path' should exists and be accesible to the user
-#
-# * for download the sourcePath should be a file that you can read 
-def check_sourcePath(path, auth_header, system):
-
-    # checks user accessibility to path using touch
-    # -r parameter is to not modify timestamp of the file (by modifiying for the same file's timestamp)
-    action = f"touch -r {path} {path}"
-
-    retval = exec_remote_command(auth_header,system,action)
-
-    app.logger.info(retval)
-
-    if retval["error"] != 0:
-        error_str=retval["msg"]
-
-        if retval["error"] == 113:
-            return {"result":False, "headers":{"X-Machine-Not-Available":"Machine is not available"} }
-            
-
-        if retval["error"] == 124:
-            return {"result":False, "headers":{"X-Timeout": "Command has finished with timeout signal"}}
-            
-
-        # error no such file
-        if in_str(error_str,"No such file"):
-            return {"result":False, "headers":{"X-Invalid-Path": "{path} is an invalid path.".format(path=path)}}
-                
-
-        # permission denied
-        if in_str(error_str,"Permission denied") or in_str(error_str,"OPENSSH"):
-            return {"result":False, "headers":{"X-Permission-Denied": "User does not have permissions to access machine or path"}}
-            
-
-        return {"result":False, "headers":{"X-Error": retval["msg"]}}
-
-    # checks using ls -ld of the path (-d is used for listing dir info not its content)
-    action = f"ls -ld {path}"
-
-    retval = exec_remote_command(auth_header,system,action)
-
-    is_dir = retval["msg"][0]
-    if is_dir ==  "d":
-        return {"result":False, "headers":{"X-A-Directory": "{path} is a directory, can't download directories".format(path=path)}}
-
-
-    return {"result":True}
-
-
-    
-# checks if path is valid for upload/download file process
-# 'path' should exists and be accesible to the user
-#
-# * for upload the targetPath should be a directory where you can write
-def check_targetPath(path, auth_header, system):
-
-    # create an empty file for testing path accesibility
-    # test file is a hidden file and has a timestamp in order to not overwrite other files created by user
-    # after this, file should be deleted
-
-    
-    timestamp = datetime.datetime.today().strftime("%Y-%m-%dT%H:%M:%S.%f")
-    # using a hash 
-    hashedTS  =  md5()
-    hashedTS.update(timestamp.encode("utf-8"))
-
-    tempFileName = f".firecrest.{hashedTS.hexdigest()}"
-
-    action = f"touch -- {path}/{tempFileName}"
-
-    retval = exec_remote_command(auth_header,system,action)
-
-    app.logger.info(retval)
-
-    if retval["error"] != 0:
-        error_str=retval["msg"]
-
-        if retval["error"] == 113:
-            return {"result":False, "headers":{"X-Machine-Not-Available":"Machine is not available"} }
-
-        if retval["error"] == 124:
-            return {"result":False, "headers":{"X-Timeout": "Command has finished with timeout signal"}}
-
-        # error no such file
-        if in_str(error_str,"No such file"):
-            return {"result":False, "headers":{"X-Invalid-Path": "{path} is an invalid path.".format(path=path)}}
-
-        # permission denied
-        if in_str(error_str,"Permission denied") or in_str(error_str,"OPENSSH"):
-            return {"result":False, "headers":{"X-Permission-Denied": "User does not have permissions to access machine or path"}}
-
-        # not a directory
-        if in_str(error_str,"Not a directory"):
-            return {"result":False, "headers":{"X-Not-A-Directory": "{path} is not a directory".format(path=path)}}
-
-        return {"result":False, "headers":{"X-Error": retval["msg"]}}    
-
-    # delete test file created
-    action = f"rm -- {path}/{tempFileName}"
-    retval = exec_remote_command(auth_header,system,action)
-
-
-    return {"result":True}
 
 def file_to_str(fileName):
 
@@ -447,7 +343,7 @@ def download_request():
         return data, 400
 
     # checks if sourcePath is a valid path
-    check = check_sourcePath(sourcePath, auth_header, system)
+    check = is_valid_file(sourcePath, auth_header, system)
 
     if not check["result"]:
         return jsonify(description="sourcePath error"), 400, check["headers"]
@@ -644,7 +540,7 @@ def upload_request():
         return data, 400
 
     # checks if sourcePath is a valid path
-    check = check_targetPath(targetPath, auth_header, system)
+    check = is_valid_dir(targetPath, auth_header, system)
 
     if not check["result"]:
         return jsonify(description="sourcePath error"), 400, check["headers"]
@@ -1016,7 +912,7 @@ def create_xfer_job(machine,auth_header,fileName):
     files = {'file': open(fileName, 'rb')}
 
     try:
-        req = requests.post("{compute_url}/jobs".
+        req = requests.post("{compute_url}/jobs/upload".
                             format(compute_url=COMPUTE_URL),
                             files=files, headers={AUTH_HEADER_NAME: auth_header, "X-Machine-Name":machine})
 

--- a/src/tests/automated_tests/integration/test_compute.py
+++ b/src/tests/automated_tests/integration/test_compute.py
@@ -21,7 +21,7 @@ SERVER_COMPUTE = os.environ.get("F7T_SYSTEMS_PUBLIC").split(";")[0]
 def submit_job(machine, headers, file='testsbatch.sh'):
 	files = {'file': ('upload.txt', open(file, 'rb'))}
 	headers.update({"X-Machine-Name": machine})
-	resp = requests.post(JOBS_URL, headers=headers, files=files)
+	resp = requests.post(f"{JOBS_URL}/upload", headers=headers, files=files)
 	print(resp.content)
 	assert resp.status_code == 201
 	return resp

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -35,9 +35,17 @@ def test_submit_job_upload(machine, expected_response_code, headers):
 	assert resp.status_code == expected_response_code
 
 # Test send a job to the systems
-@pytest.mark.parametrize("machine, expected_response_code", [ (SERVER_COMPUTE, 400) , ("someservernotavailable", 400)])
-def test_submit_job_path(machine, expected_response_code, headers):
-	data = {"targetPath" : f"{USER_HOME}/sbatch.sh"}
+@pytest.mark.parametrize("machine, targetPath, expected_response_code", [ 
+(SERVER_COMPUTE, "/srv/f7t/test_sbatch.sh", 200), 
+(SERVER_COMPUTE, "/srv/f7t/test_sbatch_forbidden.sh", 400),
+(SERVER_COMPUTE, "notexists", 400),
+(SERVER_COMPUTE, "", 400),
+(SERVER_COMPUTE, None, 400),
+("someservernotavailable", "/srv/f7t/test_sbatch.sh", 400)]
+
+)
+def test_submit_job_path(machine, targetPath, expected_response_code, headers):
+	data = {"targetPath" : targetPath}
 	headers.update({"X-Machine-Name": machine})
 	resp = requests.post(f"{JOBS_URL}/path", headers=headers, data=data)
 	print(resp.content)

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -36,8 +36,9 @@ def test_submit_job_upload(machine, expected_response_code, headers):
 
 # Test send a job to the systems
 @pytest.mark.parametrize("machine, targetPath, expected_response_code", [ 
-(SERVER_COMPUTE, "/srv/f7t/test_sbatch.sh", 200), 
+(SERVER_COMPUTE, "/srv/f7t/test_sbatch.sh", 201), 
 (SERVER_COMPUTE, "/srv/f7t/test_sbatch_forbidden.sh", 400),
+(SERVER_COMPUTE, "/srv/f7t", 400),
 (SERVER_COMPUTE, "notexists", 400),
 (SERVER_COMPUTE, "", 400),
 (SERVER_COMPUTE, None, 400),

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 import os
 from markers import host_environment_test
-
+from test_globals import *
 
 FIRECREST_URL = os.environ.get("FIRECREST_URL")
 if FIRECREST_URL:
@@ -19,19 +19,29 @@ DATA = [ (SERVER_COMPUTE, 200) , ("someservernotavailable", 400)]
 
 
 # Helper function for job submittings
-def submit_job(machine, headers):
+def submit_job_upload(machine, headers):
 	print(f"COMPUTE_URL {COMPUTE_URL}")
 	files = {'file': ('upload.txt', open('testsbatch.sh', 'rb'))}
 	headers.update({"X-Machine-Name": machine})
-	resp = requests.post(JOBS_URL, headers=headers, files=files)
+	resp = requests.post(f"{JOBS_URL}/upload", headers=headers, files=files)
 	return resp
 
 
 # Test send a job to the systems
 @pytest.mark.parametrize("machine, expected_response_code", [ (SERVER_COMPUTE, 201) , ("someservernotavailable", 400)])
-def test_submit_job(machine, expected_response_code, headers):
-	resp = submit_job(machine, headers)
+def test_submit_job_upload(machine, expected_response_code, headers):
+	resp = submit_job_upload(machine, headers)
 	print(resp.content)
+	assert resp.status_code == expected_response_code
+
+# Test send a job to the systems
+@pytest.mark.parametrize("machine, expected_response_code", [ (SERVER_COMPUTE, 400) , ("someservernotavailable", 400)])
+def test_submit_job_path(machine, expected_response_code, headers):
+	data = {"targetPath" : f"{USER_HOME}/sbatch.sh"}
+	headers.update({"X-Machine-Name": machine})
+	resp = requests.post(f"{JOBS_URL}/path", headers=headers, data=data)
+	print(resp.content)
+	print(resp.headers)
 	assert resp.status_code == expected_response_code
 
 

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -34,7 +34,14 @@ def test_download_file_not_exist(headers):
     assert resp.status_code == 400
 
 def test_download_file_not_allowed(headers):
-    data = { "sourcePath": "/etc/hosts" }
+    data = { "sourcePath": "/srv/f7t/test_sbatch_forbidden.sh" }
+    resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
+    print(resp.json())  
+    print(resp.headers)
+    assert resp.status_code == 400
+
+def test_download_dir_not_allowed(headers):
+    data = { "sourcePath": "/srv/f7t" }
     resp = requests.post(STORAGE_URL + "/xfer-external/download", headers=headers, data=data) 
     print(resp.json())  
     print(resp.headers)


### PR DESCRIPTION
- Compute endpoint can submit sbatch files located in the target system
  - Job submission until now was done uploading a sbatch file with `POST compute/jobs`
  - Now, in order to create an endpoint for job submission that allows submitting a file in a path in the target system, the endpoint `POST compute/jobs/path` has been created.
  - `POST compute/jobs/upload`will replace the old one (`POST compute/jobs`) (since RESTAPI can't return the same resource for different options with the same endpoint).
  - Changed openAPI specification.

- Changed functions `check_sourcePath` (checked if a file exists) and `check_targetPath` (checked if a directory exists) for `is_valid_file` and `is_valid_dir` and moved to `cscs_api_common.py`

- **Note**: since this branch was created before merging @aledabin's code in `dev` branch, there should be some "merge issues" to solve.