### PR TITLE
Restapi 570 invalidate storage temporary urls

### DIFF
--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -1530,7 +1530,33 @@ paths:
               description: Error
               schema:
                 type: string
-
+  '/storage/xfer-external/invalidate':
+    post:
+      summary: Invalidate temporary URL
+      description: >-
+        Remove a temporary URL attached to a given Task Id
+      tags:
+        - Storage
+      parameters:
+      - in: header
+        name: X-Task-Id
+        description: Task Id associated to the upload/download task
+        required: true
+        schema:
+          type: string
+      responses:
+        '201':
+          description: operation queued. Task Id returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invalidate-ok'
+        '400':
+          description: Error on operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
   '/tasks/':
     get:
       summary: Returns all tasks
@@ -1814,6 +1840,11 @@ components:
       type: object
       properties:
         error:
+          type: string
+    Invalidate-ok:
+      type: object
+      properties:
+        success:
           type: string
 tags:
   - name: Status

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -1538,12 +1538,12 @@ paths:
       tags:
         - Storage
       parameters:
-      - in: header
-        name: X-Task-Id
-        description: Task Id associated to the upload/download task
-        required: true
-        schema:
-          type: string
+        - in: header
+          name: X-Task-Id
+          description: Task Id associated to the upload/download task
+          required: true
+          schema:
+            type: string
       responses:
         '201':
           description: operation queued. Task Id returned.

--- a/src/storage/objectstorage.py
+++ b/src/storage/objectstorage.py
@@ -21,15 +21,11 @@ class ObjectStorage:
     @abstractmethod
     def create_container(self,containername):
          pass
-    #
-    # @abstractmethod
-    # def remove_object(self):
-    #     pass
-    #
+   
     @abstractmethod
     def get_users(self):
          pass
-    #
+    
     @abstractmethod
     def delete_object_after(self,containername,prefix,objectname,ttl):
          pass
@@ -56,6 +52,10 @@ class ObjectStorage:
 
     @abstractmethod
     def create_upload_form(self,sourcepath,containername,prefix,ttl,max_file_size):
+        pass
+
+    @abstractmethod
+    def list_objects(self,containername,prefix):
         pass
 
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -553,7 +553,7 @@ class S3v4(ObjectStorage):
         return -1
 
 
-    def delete_object(self,containername,prefix,objectname=None):
+    def delete_object(self,containername,prefix,objectname):
 
         ttl = 120
         httpVerb = "DELETE"
@@ -571,11 +571,8 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        if objectname != None:
-            canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
-        else:
-            canonical_uri = "/" + containername + "/" + prefix + "/"
-
+        canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        
         canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
 
         signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -451,12 +451,100 @@ class S3v4(ObjectStorage):
 
         canonical_querystring += '&X-Amz-Signature=' + signature
 
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
-
         url = endpoint_url + canonical_uri + "?" + canonical_querystring
 
         return url
+
+    def list_objects(self,containername,prefix=None):
+        httpVerb = "GET"
+        algorithm = 'AWS4-HMAC-SHA256'
+        service = "s3"
+        aws_request = "aws4_request"
+        aws_access_key_id = self.user  
+        aws_secret_access_key = self.passwd  
+        endpoint_url = self.url  
+        host = self.url.split("/")[-1]  
+        region = "us-east-1"
+
+        # Create a date for headers and the credential string
+        t = datetime.utcnow()
+        amzdate = t.strftime('%Y%m%dT%H%M%SZ')
+        datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
+
+        canonical_uri = f"/{containername}" 
+
+        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+
+        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
+
+        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
+
+        # canonical_querystring = bucket_name+"/"+object_name
+        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
+        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
+            aws_access_key_id + '/' + credential_scope)
+        canonical_querystring += '&X-Amz-Date=' + amzdate
+        canonical_querystring += '&X-Amz-Expires=' + str(120)
+        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
+
+        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
+
+        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
+
+        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
+            canonical_request.encode("utf-8")).hexdigest()
+
+        # Create the signing key
+        signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
+
+        # Sign the string_to_sign using the signing_key
+        signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
+
+        canonical_querystring += '&X-Amz-Signature=' + signature
+
+        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+
+        try:
+            resp = requests.get(url)
+
+            if resp.ok:
+                # logging.info(resp.content)
+                root = ElementTree.fromstring(resp.content)
+
+                for _, nsvalue in ElementTree.iterparse(BytesIO(resp.content), events=['start-ns']):
+                    namespace = nsvalue[1]
+
+                object_list = []
+
+                
+
+                for contents in root.findall("{{{}}}Contents".format(namespace)):
+                    key = contents.find("{{{}}}Key".format(namespace)).text
+
+                    
+                    if prefix != None:
+                        sep = key.split("/")
+                        if prefix == sep[0]:
+                            name = key.split("/")[-1]
+                            object_list.append(name)
+                            continue
+                    
+                    object_list.append(key)
+
+
+                    
+
+                return object_list
+            else:
+                return None
+        except requests.exceptions.ConnectionError as ce:
+            logging.error(ce.strerror)
+            return None
+
+        except Exception as e:
+            logging.error("Error: {}".format(e))
+            logging.error("Error: {}".format(type(e)))
+            return None
 
     def delete_object_after(self,containername,prefix,objectname,ttl):
 
@@ -465,17 +553,17 @@ class S3v4(ObjectStorage):
         return -1
 
 
-    def delete_object(self,containername,prefix,objectname):
+    def delete_object(self,containername,prefix,objectname=None):
 
         ttl = 120
         httpVerb = "DELETE"
         algorithm = 'AWS4-HMAC-SHA256'
         service = "s3"
         aws_request = "aws4_request"
-        aws_access_key_id = self.user# "storage_access_key"
-        aws_secret_access_key = self.passwd #"storage_secret_key"
-        endpoint_url = self.url #"http://192.168.220.19:9000"
-        host = self.url.split("/")[-1] #192.168.220.19:9000"
+        aws_access_key_id = self.user
+        aws_secret_access_key = self.passwd 
+        endpoint_url = self.url 
+        host = self.url.split("/")[-1] 
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -483,7 +571,10 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        if objectname != None:
+            canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        else:
+            canonical_uri = "/" + containername + "/" + prefix + "/"
 
         canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
 
@@ -513,20 +604,15 @@ class S3v4(ObjectStorage):
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
         canonical_querystring += '&X-Amz-Signature=' + signature
-
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
-
+        
         url = endpoint_url + canonical_uri + "?" + canonical_querystring
 
-        logging.info("Deleting {}/{}/{}".format(containername,prefix,objectname))
+        logging.info(f"Deleting {canonical_uri}")
         logging.info("URL: {}".format(url))
 
         try:
             resp = requests.delete(url)
-            # print(resp.status_code)
-            # print(resp.text)
-
+            
             if resp.ok:
                 logging.info("Object deleted succesfully")
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -512,7 +512,7 @@ def invalidate_request():
         if error == -1:
             return jsonify(error="Could not invalidate URL"), 400
 
-    return jsonify(success="URL invalidated successfully"), 200
+    return jsonify(success="URL invalidated successfully"), 201
 
 
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -472,12 +472,52 @@ def download_request():
         task_url = "{kong_url}/tasks/{task_id}".format(kong_url=KONG_URL, task_id=task_id)
 
         data = jsonify(success="Task created", task_url=task_url, task_id=task_id)
-        return data, 200
+        return data, 201
 
     except Exception as e:
         data = jsonify(error=e)
         return data, 400
 
+
+# invalidate temp URLs
+# parameters:
+# - X-Task-Id: task id of the transfer related to the URL that wants to be invalidated
+@app.route("/xfer-external/invalidate", methods=["POST"])
+@check_auth_header
+def invalidate_request():
+    try:
+
+        task_id = request.headers["X-Task-Id"]
+    except KeyError as e:
+        return jsonify(error="Header X-Task-Id missing"), 400
+
+    auth_header = request.headers[AUTH_HEADER_NAME]
+
+    # search if task belongs to the user
+    task_status = get_task_status(task_id, auth_header)
+    
+    if task_status == -1:
+        return jsonify(error="Invalid X-Task-Id"), 400
+    
+
+    containername = get_username(auth_header)
+    prefix        = task_id
+
+    objects = staging.list_objects(containername,prefix)
+
+    for objectname in objects:
+
+        error = staging.delete_object(containername,prefix,objectname)
+
+        if error == -1:
+            return jsonify(error="Could not invalidate URL"), 400
+
+    return jsonify(success="URL invalidated successfully"), 200
+
+
+
+
+    
 
 # async task for upload large files
 # user: user in the posix file system
@@ -639,7 +679,7 @@ def upload_request():
         task_url = "{kong_url}/tasks/{task_id}".format(kong_url=KONG_URL,task_id=task_id)
 
         data = jsonify(success="Task created",task_url=task_url,task_id=task_id)
-        return data, 200
+        return data, 201
 
     except Exception as e:
         data = jsonify(error=e.message)
@@ -654,7 +694,7 @@ def get_file_from_storage(auth_header,system,path,download_url,fileName):
                     format(url=download_url,system=system))
 
     # wget to be executed on cluster side:
-    action = f"wget -q -O {path}/{fileName} -- \"{downdload_url}\" "
+    action = f"wget -q -O {path}/{fileName} -- \"{download_url}\" "
 
     app.logger.info(action)
 

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -275,10 +275,14 @@ class Swift(ObjectStorage):
             logging.error(e)
             return -1
 
-    def delete_object(self,containername,prefix,objectname):
+    def delete_object(self,containername,prefix,objectname=None):
 
-        swift_account_url = "{swift_url}/{containername}/{prefix}/{objectname}".format(
-            swift_url=self.url, containername=containername, prefix=prefix, objectname=objectname)
+        if objectname!=None:
+
+            swift_account_url = f"{self.url}/{containername}/{prefix}/{objectname}"
+        
+        else:
+            swift_account_url = f"{self.url}/{containername}/{prefix}"
 
         header = {"X-Auth-Token": self.auth}
 

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -251,6 +251,42 @@ class Swift(ObjectStorage):
 
         return retval
 
+    def list_objects(self,containername,prefix=None):
+        # object_prefix = "{prefix}/{objectname}".format(prefix=prefix, objectname=objectname)
+
+        url = f"{self.url}/{containername}"
+
+        print(url)
+
+        try:
+            req = requests.get(url, headers={"X-Auth-Token": self.auth})
+            if req.ok:
+                print(req.content)
+
+                values = req.content.decode("utf-8")
+                object_list = values.split("\n")[0:-1] # last element on the list is a ''
+
+                if prefix:
+                    new_object_list = []
+                    for obj in object_list:
+                        
+                        key = obj.split("/")
+                        val = key[1]
+                        key = key[0]
+                        
+                        if key == prefix:
+                            new_object_list.append(val)
+
+                    #object_list = list(filter(lambda obj: obj.split("/")[0] == prefix, object_list))
+                return new_object_list
+            return None
+
+        except Exception as e:
+
+            logging.error(type(e))
+
+            return None
+
 
     # sets time to live (TTL) for an object in SWIFT
     def delete_object_after(self,containername,prefix,objectname,ttl):

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -255,14 +255,11 @@ class Swift(ObjectStorage):
         # object_prefix = "{prefix}/{objectname}".format(prefix=prefix, objectname=objectname)
 
         url = f"{self.url}/{containername}"
-
-        print(url)
-
+        
         try:
             req = requests.get(url, headers={"X-Auth-Token": self.auth})
             if req.ok:
-                print(req.content)
-
+                
                 values = req.content.decode("utf-8")
                 object_list = values.split("\n")[0:-1] # last element on the list is a ''
 
@@ -311,14 +308,9 @@ class Swift(ObjectStorage):
             logging.error(e)
             return -1
 
-    def delete_object(self,containername,prefix,objectname=None):
+    def delete_object(self,containername,prefix,objectname):
 
-        if objectname!=None:
-
-            swift_account_url = f"{self.url}/{containername}/{prefix}/{objectname}"
-        
-        else:
-            swift_account_url = f"{self.url}/{containername}/{prefix}"
+        swift_account_url = f"{self.url}/{containername}/{prefix}"
 
         header = {"X-Auth-Token": self.auth}
 

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -42,7 +42,7 @@ def test_post_upload_request(headers):
     # request upload form
     data = { "sourcePath": "testsbatch.sh", "targetPath": USER_HOME }
     resp = requests.post(STORAGE_URL + "/xfer-external/upload", headers=headers, data=data)
-    assert resp.status_code == 200
+    assert resp.status_code == 201
 
     task_id = resp.json()["task_id"]
 

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -15,7 +15,7 @@ else:
 def test_post_upload_request(headers):
     data = { "sourcePath": "testsbatch.sh", "targetPath": USER_HOME }
     resp = requests.post(STORAGE_URL + "/xfer-external/upload", headers=headers, data=data)
-    assert resp.status_code == 200
+    assert resp.status_code == 201
 
 def test_download_file_not_exist(headers):
     data = { "sourcePath": "no-existing-file" }


### PR DESCRIPTION
Added `storage/xfer-external/invalidate` endpoint in API.
- There's no native way to invalidate a temporary URL on SWIFT or S3, therefore it uses the header `X-Task-Id` to track the file that was uploaded/downloaded to the staging area and remove it on demand of the client.
- Created a new function `list_objects` for S3 and SWIFT classes that filters objects by prefix (since for Object Storage tech a prefix is a part of the object and it's not natively filtered).
- Also updated OpenAPI spec with a new endpoint.

Note: @fcndl we should create a test for this endpoint after the merge (since we can use `/srv/f7t` files that are in the `dev` branch but not in this one since it was created before the last merge).
