### PR TITLE
Restapi 583 timeout issue on storage xfer external download

### DIFF
--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -95,6 +95,9 @@ services:
     environment:
       - F7T_PERSIST_PORT=6379
       - F7T_PERSIST_PWD=rediS2200
+      - F7T_DEBUG_MODE=True
+      - F7T_COMPUTE_TASK_EXP_TIME=86400
+      - F7T_STORAGE_TASK_EXP_TIME=2678400
     depends_on:
       - "taskpersistence"
     networks:

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -61,6 +61,8 @@ services:
       - F7T_PERSIST_PORT=6379
       - F7T_PERSIST_PWD=rediS2200
       - F7T_DEBUG_MODE=True
+      - F7T_COMPUTE_TASK_EXP_TIME=86400
+      - F7T_STORAGE_TASK_EXP_TIME=2678400
     depends_on:
       - "taskpersistence"
     network_mode: "host"
@@ -100,7 +102,7 @@ services:
       - "9000:9000"
     
   taskpersistence:
-    image: redis:latest
+    image: redis:5
     command: redis-server /redis.conf
     network_mode: "host"
     volumes:

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -73,7 +73,7 @@ F7T_STORAGE_JOBS_MACHINE=system01
 # expiration time (in secs) for expiration of URL and files (604800=7 days)
 F7T_STORAGE_TEMPURL_EXP_TIME=604800
 # staging area max size file supported (in MBytes)
-F7T_STORAGE_MAX_FILE_SIZE=5120
+F7T_STORAGE_MAX_FILE_SIZE=512000
 # Storage technology used for staging area (swift or s3v2 or s3v4, unset to disable)
 F7T_OBJECT_STORAGE='s3v4'
 #-------

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -1,137 +1,24 @@
 openapi: 3.0.0
 servers:
-  - url: 'http://127.0.0.1/api'
-  - url: 'https://127.0.0.1/api'
+  - url: 'http://FIRECREST_URL'
+  - url: 'https://FIRECREST_URL'
 info:
-  version: 0.9.9
-  title: FirecREST API
+  version: 1.0.0-RC1
+  title: FirecREST Developers API
   description: >
-    FirecREST platform, a RESTful Services Gateway to HPC resources, is a
-    high-performance and reusable framework that integrates with existing HPC
-    infrastructure, thus enabling the access to HPC resources to web-enabled
-    services.
-    
-    
-    FirecREST provides a REST API that defines a set of functions through which
-    developers can interact with using the HTTP/REST protocol architecture.
-    Calls to the REST API received by the services gateway are translated into
-    the appropriate infrastructure requests. Among the most prominent services
-    that FirecREST exposes we find authentication and authorization, system
-    status, file-system access, data mover, execution of parallel jobs,
-    accounting information, etc.
+    This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.
 paths:
-  /aai/login:
-    post:
-      summary: Login
-      tags:
-        - AAI
-      responses:
-        '200':
-          description: Login successful
-        '400':
-          description: Login error
-  /aai/logout:
-    get:
-      summary: Logout
-      tags:
-        - AAI
-      responses:
-        '200':
-          description: Logout completed
-        '400':
-          description: Logout failed
-  /aai/status:
-    get:
-      summary: Authorization status
-      tags:
-        - AAI
-      responses:
-        '200':
-          description: Current auth status and information
-          content:
-            application/JSON:
-              schema:
-                $ref: '#/components/schemas/Session'
-  '/aai/TTS/ssh/keys/{user}':
-    parameters:
-      - name: user
-        in: path
-        description: user that is related to the current keys
-        required: true
-        schema:
-          type: string
-    get:
-      summary: Obtain the ssh keys related to the user
-      description: Keys stored in
-      tags:
-        - AAI
-        - TTS
-      responses:
-        '200':
-          description: Return ssh key pair
-    post:
-      summary: Create a new pair of ssh keys for the user
-      tags:
-        - AAI
-        - TTS
-      responses:
-        '201':
-          description: resource created at location
-    delete:
-      summary: Detele ssh keys related to the user
-      tags:
-        - AAI
-        - TTS
-      responses:
-        '200':
-          description: keys deleted
-  /aai/TTS/ssh/certificate:
-    get:
-      summary: Obtain a ssh-certificate from authorization token
-      tags:
-        - AAI
-        - TTS
-      parameters:
-        - name: user
-          in: query
-          description: user on the system
-          required: true
-          schema:
-            type: string
-          allowReserved: false
-        - name: duration
-          in: query
-          description: 'time duration (in seconds) of certificate, starting at request time'
-          required: true
-          schema:
-            type: string
-          allowReserved: false
-        - name: system
-          in: query
-          description: Target system to which access is required
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-      responses:
-        '200':
-          description: Returns SSH certificate generated
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-  /status/services:
+  '/status/services':
     get:
       summary: List of services
       description: >-
         Returns a list containing all available micro services with a name,
-        description, status, and endpoint.
+        description, and status.
       tags:
         - Status
-      parameters:
-        - $ref: '#/components/parameters/pageSize'
-        - $ref: '#/components/parameters/pageNumber'
+      # parameters:
+      #   - $ref: '#/components/parameters/pageSize'
+      #   - $ref: '#/components/parameters/pageNumber'
       responses:
         '200':
           description: List of services with status and description.
@@ -152,8 +39,7 @@ paths:
     get:
       summary: Get service information
       description: >-
-        Returns a single service descriptor (name, description, status, and
-        endpoint) from its name
+        Returns a single service descriptor (name, description and status) from its name.
       tags:
         - Status
       responses:
@@ -165,18 +51,18 @@ paths:
                 $ref: '#/components/schemas/Service'
         '404':
           description: Service does not exists
-  /status/systems:
+  '/status/systems':
     get:
       summary: List of systems
-      description: Returns a list containing all available systems and response status
+      description: Returns a list containing all available systems and response status.
       tags:
         - Status
-      parameters:
-        - $ref: '#/components/parameters/pageSize'
-        - $ref: '#/components/parameters/pageNumber'
+      # parameters:
+      #   - $ref: '#/components/parameters/pageSize'
+      #   - $ref: '#/components/parameters/pageNumber'
       responses:
         '200':
-          description: List of systems with status and description.
+          description: List of systems with status and description
           content:
             '*/*':
               schema:
@@ -194,7 +80,7 @@ paths:
         schema:
           type: string
     get:
-      summary: Get system information.
+      summary: Get system information
       description: Returns a single system from its name.
       tags:
         - Status
@@ -207,10 +93,24 @@ paths:
                 $ref: '#/components/schemas/System'
         '404':
           description: System does not exists
-  '/utilities/{machinename}/ls':
+  '/status/parameters':
+    get:
+      summary: List of API parameters
+      description: Returns list of parameters that can be configured in environment files.
+      tags:
+        - Status
+      responses:
+        '200':
+          description: List of parameters and values
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Parameters'
+
+  '/utilities/ls':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
@@ -218,25 +118,25 @@ paths:
     get:
       summary: List directory contents
       description: >-
-        Returns a list of contents at the specified path on the {machine}
+        Returns a list of contents at the specified path on the {X-Machine-Name}
         filesystem.
       tags:
         - Utilities
       parameters:
-        - name: path
+        - name: targetPath
           in: query
-          description: Absolute filesystem path
+          description: Absolute path to destination
           required: true
           schema:
             type: string
           allowReserved: true
         - name: showhidden
           in: query
-          description: do not ignore entries starting with '.'
+          description: Show entries starting with '.'
           schema:
             type: boolean
-        - $ref: '#/components/parameters/pageSize'
-        - $ref: '#/components/parameters/pageNumber'
+        # - $ref: '#/components/parameters/pageSize'
+        # - $ref: '#/components/parameters/pageNumber'
       responses:
         '200':
           description: List of contents of path
@@ -254,48 +154,56 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or path
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <path> is an invalid path
               schema:
-                type: integer
-  '/utilities/{machinename}/mkdir':
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+  '/utilities/mkdir':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
     post:
       summary: Creates a directory
-      description: 'Create a directory at the specified path on the {machine} filesystem'
+      description: 'Create a directory at the specified path on the {X-Machine-Name} filesystem.'
       tags:
         - Utilities
-      parameters:
-        - name: path
-          in: query
-          description: Filesystem path
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: p
-          in: query
-          description: 'No error if existing, make parent directories as needed'
-          allowEmptyValue: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                p:
+                  type: string
+                  description: No error if existing, make parent directories as needed
+              required:
+                - targetPath
+              example:
+                targetPath: /home/user/newdir
+                p:
       responses:
-        '200':
+        '201':
           description: Directory created
         '400':
           description: Error creating directory
@@ -307,53 +215,61 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or path
               schema:
-                type: integer
+                type: string
             X-Exists:
               description: <path> already exists
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <path> is an invalid path
               schema:
-                type: integer
-  '/utilities/{machinename}/rename':
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+  '/utilities/rename':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
-    post:
+    put:
       summary: 'Rename/move a file, directory, or symlink'
       description: >-
-        Rename/move a file, directory, or symlink at the specified old path to
-        the new path on the {machine} filesystem
+        Rename/move a file, directory, or symlink at the sourcePath to
+        the targetPath on the {X-Machine-Name} filesystem.
       tags:
         - Utilities
-      parameters:
-        - name: source
-          in: query
-          description: Absolute path to source
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: dest
-          in: query
-          description: Absolute path to destination
-          required: true
-          schema:
-            type: string
-          allowReserved: true
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data': # FIXME: this doesn't work for put requests
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: Absolute path to source
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/user/file
+                targetPath: /home/user/file-renamed
       responses:
         '200':
           description: Success to rename file or directory
@@ -367,56 +283,63 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or paths
               schema:
-                type: integer
+                type: string
             X-Not-Found:
               description: <oldpath> not found
               schema:
-                type: integer
+                type: string
             X-Exists:
               description: <newpath> already exists
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <oldpath> and/or <newpath> are invalid paths
               schema:
-                type: integer
-  '/utilities/{machinename}/chmod':
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+  '/utilities/chmod':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
-    post:
+    put:
       summary: Change file mode bits
-      description: Change the file mod bits of a given file according to the specified mode
+      description: Change the file mod bits of a given file according to the specified mode.
       tags:
         - Utilities
-      parameters:
-        - name: path
-          in: query
-          description: Absolute filesystem path to file
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
-          allowReserved: true
-        - name: mode
-          in: query
-          description: Same as numeric mode of linux chmod tool
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data': # FIXME: this doesn't work for put requests
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                mode:
+                  type: string
+                  description: Same as numeric mode of linux chmod tool
+              required:
+                - targetPath
+                - mode
+              example:
+                targetPath: /home/user/file
+                mode: "700"
       responses:
         '200':
           description: Operation completed
@@ -424,42 +347,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Application-output'
-  '/utilities/{machinename}/chown':
+        '400':
+          description: Error in chmod operation
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or paths
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is an invalid path
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+            X-Invalid-Mode:
+              description: <mode> is an invalid mode
+              schema:
+                type: string
+  '/utilities/chown':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
-    post:
+    put:
       summary: Change file owner and group
       description: >-
         Changes the user and/or group ownership of a given file. If only owner
         or group information is passed, only that information will be updated.
       tags:
         - Utilities
-      parameters:
-        - name: path
-          in: query
-          description: Absolute filesystem path to file
-          required: true
-          allowEmptyValue: false
-          schema:
-            type: string
-          allowReserved: true
-        - name: owner
-          in: query
-          required: false
-          allowEmptyValue: false
-          schema:
-            type: string
-        - name: group
-          in: query
-          required: false
-          allowEmptyValue: false
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                owner:
+                  type: string
+                  description: Owner username for target
+                group:
+                  type: string
+                  description: group username for target
+              required:
+                - targetPath
+              example:
+                targetPath: /home/user/file
+                owner: newOwner
+                group: newGroup
       responses:
         '200':
           description: Operation completed
@@ -467,21 +422,132 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Application-output'
-  '/utilities/{machinename}/file':
+        '400':
+          description: Error in chwon operation
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or paths
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is an invalid path
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+            X-Invalid-Owner:
+              description: <owner> is an invalid user
+              schema:
+                type: string
+            X-Invalid-Group:
+              description: <group> is an invalid group
+              schema:
+                type: string
+  '/utilities/copy':
     parameters:
-      - name: machinename
-        in: path
-        description: The system name.
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Copy file from a filesystem path to another
+      description: >-
+        Copies file from {sourcePath} to {targetPath}.
+      tags:
+        - Utilities
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: Absolute filesystem path to file to be copied
+                targetPath:
+                  type: string
+                  description: Absolute filesystem path where the {sourcePath} is copied
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/user/file
+                targetPath: /home/user/file-copied
+      responses:
+        '201':
+          description: Object copy succesful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application-output'
+        '400':
+          description: Error in copy operation
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or paths
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is an invalid path
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+            X-Exists:
+              description: <targetPath> already exists
+              schema:
+                type: string
+            X-Not-Found:
+              description: <sourcePath> not found
+              schema:
+                type: string
+  '/utilities/file':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
         required: true
         schema:
           type: string
     get:
       summary: determine file type
-      description: Uses the file linux application to determine the type of a file
+      description: Uses the file linux application to determine the type of a file on the
+        {X-Machine-Name} filesystem.
       tags:
         - Utilities
       parameters:
-        - name: path
+        - name: targetPath
           in: query
           description: Absolute filesystem path
           required: true
@@ -496,36 +562,75 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Application-output'
-  '/utilities/{machinename}/symlink':
+        '400':
+          description: Error in file operation
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or paths
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is an invalid path
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+        '401':
+          description: No auth header given
+          content:
+            text/plain:
+              schema:
+                type: string
+  '/utilities/symlink':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
     post:
       summary: Create a symlink
-      description: Create a symbolic link (symlink) on a machine filesystem
+      description: Create a symbolic link (symlink) on the
+        {X-Machine-Name} filesystem.
       tags:
         - Utilities
-      parameters:
-        - name: target
-          in: query
-          description: path to target that the symlink will point to
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: source
-          in: query
-          description: absolute path to the new symlink
-          required: true
-          schema:
-            type: string
-          allowReserved: true
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                linkPath:
+                  type: string
+                  description: Absolute path to the new symlink
+                targetPath:
+                  type: string
+                  description: Absolute filesystem path to target that the symlink will point to
+              required:
+                - linkPath
+                - targetPath
+              example:
+                targetPath: /home/user/file
+                linkPath: /home/user/file-linked
+
       responses:
-        '200':
+        '201':
           description: Success create the symlink
         '400':
           description: Failed to create symlink
@@ -537,42 +642,46 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or paths
               schema:
-                type: integer
+                type: string
             X-Exists:
               description: <source> already exists
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <target> and/or <source> are invalid paths
               schema:
-                type: integer
-  '/utilities/{machinename}/download':
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+  '/utilities/download':
     parameters:
-      - name: machinename
-        in: path
-        description: The system name.
+      - in: header
+        name: X-Machine-Name
+        description: The system name
         required: true
         schema:
           type: string
     get:
       summary: Download a small file
       description: >-
-        'Blocking call that returns the file from the specified path on the
-        {machine} filesystem.'
+        Blocking call that returns the file from the specified path on the
+        {X-Machine-Name} filesystem.
       tags:
         - Utilities
       parameters:
-        - name: path
+        - name: sourcePath
           in: query
-          description: path to the file to download
+          description: Path to the file to download
           required: true
           schema:
             type: string
@@ -595,55 +704,54 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or path
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <path> is invalid
               schema:
-                type: integer
-  '/utilities/{machinename}/upload':
+                type: string
+  '/utilities/upload':
     parameters:
-      - name: machinename
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
     post:
       summary: Uploads a small file
-      description: 'Uploads a file to the specified path on the {machine} filesystem.'
+      description: 'Uploads a file to the specified path on the {X-Machine-Name} filesystem.'
       tags:
         - Utilities
-      parameters:
-        - name: path
-          in: query
-          description: >-
-            target path to the location where file will be uploaded to on the
-            {machine} filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
       requestBody:
-        description: File to be uploaded
         required: true
         content:
-          '*/*':
+          'multipart/form-data':
             schema:
               type: object
               properties:
                 file:
                   type: string
                   format: binary
+                  description: File to be uploaded
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+              required:
+                - file
+                - targetPath
+              example:
+                file: "@/home/local/file"
+                targetPath: /home/user/remotefile
       responses:
-        '200':
+        '201':
           description: File upload successful
         '400':
           description: Failed to upload file
@@ -655,29 +763,204 @@ paths:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
               schema:
-                type: integer
+                type: string
             X-Machine-Not-Available:
               description: Machine is not available
               schema:
-                type: integer
+                type: string
             X-Permission-Denied:
               description: User does not have permissions to access machine or path
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: <path> is invalid.
               schema:
-                type: integer
-  '/jobs/{machine}':
+                type: string
+  '/utilities/rm':
     parameters:
-      - name: machine
-        in: path
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    delete:
+      summary: Delete a small file
+      description: 'Delete a file to the specified path on the {X-Machine-Name} filesystem.'
+      tags:
+        - Utilities
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data': # FIXME
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+              required:
+                - targetPath
+              example:
+                targetPath: /home/user/remotefile
+      responses:
+        '204':
+          description: File deletion successful
+        '400':
+          description: Failed to delete file
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or path
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is invalid.
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+  '/utilities/checksum':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Calculate the checksum of a given file
+      description: 'Calculate the SHA256 (256-bit) checksum of a specified file in {targetPath} on the {X-Machine-Name} filesystem.'
+      tags:
+        - Utilities
+      parameters: 
+        - name: targetPath
+          in: query
+          description: Path to the file to calculate checksum
+          required: true
+          schema:
+            type: string
+          allowReserved: true
+      responses:
+        '200':
+          description: Checksum successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
+        '400':
+          description: Error obatining checksum
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or path
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is invalid.
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+            X-A-Directory:
+              description: <targetPath> is a directory, can't checksum directories
+              schema:
+                type: string
+  '/utilities/view':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    get:
+      summary: View the content of a given file
+      description: 'View the content of a specified file in {targetPath} on the {X-Machine-Name} filesystem.'
+      tags:
+        - Utilities
+      parameters: 
+        - name: targetPath
+          in: query
+          description: Path to the file to view
+          required: true
+          schema:
+            type: string
+          allowReserved: true
+      responses:
+        '200':
+          description: File content successfully returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
+        '400':
+          description: Failed to view file content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or path
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is invalid.
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+            X-A-Directory:
+              description: <targetPath> is a directory, can't checksum directories
+              schema:
+                type: string
+  '/compute/jobs/upload':
+    parameters:
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
           type: string
     post:
-      summary: Submit Job
+      summary: Submit Job by uploading a local sbatch file
       description: >-
         Non-blocking call. Submits a batch script to SLURM on the target system.
         The batch script is uploaded as a file to the microservice which then
@@ -688,36 +971,31 @@ paths:
       tags:
         - Compute
       requestBody:
-        description: SBATCH script file to be submitted to SLURM
         required: true
         content:
-          '*/*':
+          'multipart/form-data':
             schema:
               type: object
               properties:
                 file:
                   type: string
                   format: binary
+                  description: SBATCH script file to be submitted to SLURM
+              required:
+                - file
       responses:
-        '200':
+        '201':
           description: Task for job creation queued successfully
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: Related task id
-                  url:
-                    type: string
-                    description: url to task
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Failed to submit job file
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
@@ -735,9 +1013,78 @@ paths:
               description: sbatch returned error
               schema:
                 type: integer
+  '/compute/jobs/path':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    post:
+      summary: Submit Job by a given remote sbatch file
+      description: >-
+        Non-blocking call. Submits a batch script to SLURM on the target system.
+        The batch script is uploaded as a file to the microservice which then
+        stores it in a temporal directory in preparation to be submitted to the
+        workload manager. The operation returns the task id associated to the
+        Task microservice that will contain information of the SLURM job once
+        it is created.
+      tags:
+        - Compute
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: path to the SBATCH script file stored in {X-Machine-Name} machine to be submitted to SLURM
+              required:
+                - targetPath
+      responses:
+        '201':
+          description: Task for job creation queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-ok'
+        '400':
+          description: Failed to submit job file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: integer
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: integer
+            X-Permission-Denied:
+              description: User does not have permissions to access machine
+              schema:
+                type: integer
+            X-sbatch-error:
+              description: sbatch returned error
+              schema:
+                type: integer
+  '/compute/jobs':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
     get:
       summary: Retrieves information from all jobs
-      description: Information about jobs on the SLURM scheduling queue (squeue)
+      description: Information about jobs on the SLURM scheduling queue. This call uses the `squeue` command.
       tags:
         - Compute
       parameters:
@@ -756,9 +1103,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/jobs'
+                $ref: '#/components/schemas/Jobs'
         '400':
           description: Failed to retrieve job information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
@@ -772,10 +1123,10 @@ paths:
               description: User does not have permissions to access machine
               schema:
                 type: integer
-  '/jobs/{machine}/{jobid}':
+  '/compute/jobs/{jobid}':
     parameters:
-      - name: machine
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
@@ -788,7 +1139,7 @@ paths:
           type: string
     get:
       summary: Retrieves information from a job
-      description: Information about a jobs on the SLURM scheduling queue (squeue)
+      description: Information about a job on the SLURM scheduling queue. This call uses the `squeue` command.
       tags:
         - Compute
       responses:
@@ -797,9 +1148,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/job'
+                $ref: '#/components/schemas/Job'
         '400':
-          description: Failed to retrieve job information
+          description: Failed to retrieve jobs information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Machine-Does-Not-Exist:
               description: Machine does not exist
@@ -815,28 +1170,39 @@ paths:
                 type: integer
     delete:
       summary: Delete Job
-      description: Cancel job from SLURM using scancel command
+      description: Cancel job from SLURM, using the `scancel` command.
       tags:
         - Compute
-      parameters:
-        - name: jobs
-          in: query
-          description: Job id to delete.
-          schema:
-            type: string
       responses:
-        '200':
+        '204':
           description: Job deleted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/jobs'
+                $ref: '#/components/schemas/Jobs'
         '400':
           description: Failed to delete job
-  '/jobs/{machine}/sacct':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: integer
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: integer
+            X-Permission-Denied:
+              description: User does not have permissions to access machine
+              schema:
+                type: integer
+  '/compute/acct':
     parameters:
-      - name: machine
-        in: path
+      - in: header
+        name: X-Machine-Name
         description: The system name
         required: true
         schema:
@@ -845,13 +1211,13 @@ paths:
       summary: Job account information
       description: >-
         Reports accounting data of job in the SLURM job accounting log, this
-        include information from completed jobs
+        includes information from completed jobs. This call uses the `sacct` command.
       tags:
         - Compute
       parameters:
         - name: jobs
           in: query
-          description: Comma-separated list of job IDs to retrieve.
+          description: Comma-separated list of job IDs to retrieve
           schema:
             type: array
             items:
@@ -865,17 +1231,17 @@ paths:
             MM/DD[/YY]-HH:MM[:SS]
             YYYY-MM-DD[THH:MM[:SS]]
           required: false
-          schema: 
+          schema:
             type: string
         - name: endtime
           in: query
-          description: End time (and/or date) of sacct query. Allowed formats are 
+          description: End time (and/or date) of sacct query. Allowed formats are
             HH:MM[:SS] [AM|PM]
             MMDD[YY] or MM/DD[/YY] or MM.DD[.YY]
             MM/DD[/YY]-HH:MM[:SS]
             YYYY-MM-DD[THH:MM[:SS]]
           required: false
-          schema: 
+          schema:
             type: string
       responses:
         '200':
@@ -883,67 +1249,88 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/jobs'
-  /storage/xfer-internal/rsync:
-    get:
+                $ref: '#/components/schemas/Jobs'
+        '400':
+          description: Failed to retrieve account information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: integer
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: integer
+            X-Permission-Denied:
+              description: User does not have permissions to access machine
+              schema:
+                type: integer
+  '/storage/xfer-internal/rsync':
+    post:
       summary: rsync
       description: >-
         Data transfer between internal CSCS file systems. To transfer files and
-        folders from /users, /project or /store to the /scratch file systems for
+        folders from `/users`, `/project` or `/store` to the `/scratch` file systems for
         stage-in or stage-out jobs. Reference:
         https://user.cscs.ch/storage/transfer/internal/
       tags:
         - Storage
-      parameters:
-        - name: sourcePath
-          in: query
-          description: source path to the location filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: targetPath
-          in: query
-          description: target path to the location filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: jobName
-          in: query
-          description: job name the rsync operation
-          schema:
-            type: string
-        - name: time
-          in: query
-          description: >-
-            'Limit on the total run time of the rsync. Acceptable time formats 
-            \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
-            \'days-hours\', \'days-hours:minutes\' and
-            \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
-            xfer job.'
-          schema:
-            type: string
-            default: '02:00:00'
-        - name: stageOutJobId
-          in: query
-          description: Move data after job with id 'stageOutJobId' is completed
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: Source path to the location filesystem
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                jobName:
+                  type: string
+                  description: job name the rsync operation
+                  default: rsync-job
+                time:
+                  type: string
+                  description: >-
+                    Limit on the total run time of the rsync. Acceptable time formats
+                    \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
+                    \'days-hours\', \'days-hours:minutes\' and
+                    \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
+                    xfer job.
+                  default: '02:00:00'
+                stageOutJobId:
+                  type: string
+                  description: Move data after job with id {stageOutJobId} is completed
+                  default: null
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/user/origin
+                targetPath: /home/user/destination
+                jobName: rsync-firecrest-job
+                stageOutJobId: "123456"
+                time: "2-03:00:00"
       responses:
-        '200':
-          description: rsync operation queued. Job Id returned.
+        '201':
+          description: operation queued. Task Id returned.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                description: Job id
+                $ref: '#/components/schemas/Upload-ok'
         '400':
-          description: Error on rsync operation
+          description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access paths
@@ -961,8 +1348,8 @@ paths:
               description: sourcePath and/or targetPath are invalid paths.
               schema:
                 type: integer
-  /storage/xfer-internal/mv:
-    get:
+  '/storage/xfer-internal/mv':
+    post:
       summary: move (rename) files
       description: >-
         'Move files between internal CSCS file systems. Rename sourcePath to
@@ -972,56 +1359,58 @@ paths:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
       tags:
         - Storage
-      parameters:
-        - name: sourcePath
-          in: query
-          description: source path to the location filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: targetPath
-          in: query
-          description: target path to the location filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: jobName
-          in: query
-          description: job name the operation
-          schema:
-            type: string
-        - name: time
-          in: query
-          description: >-
-            'Limit on the total run time of the rsync. Acceptable time formats 
-            \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
-            \'days-hours\', \'days-hours:minutes\' and
-            \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
-            xfer job.'
-          schema:
-            type: string
-            default: '02:00:00'
-        - name: stageOutJobId
-          in: query
-          description: Perform operation after job with id 'stageOutJobId' is completed
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: source path to the location filesystem
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                jobName:
+                  type: string
+                  description: job name the rename operation
+                  default: mv-job
+                time:
+                  type: string
+                  description: >-
+                    'Limit on the total run time of the rename. Acceptable time formats
+                    \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
+                    \'days-hours\', \'days-hours:minutes\' and
+                    \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
+                    xfer job.'
+                  default: '02:00:00'
+                stageOutJobId:
+                  type: string
+                  description: Move data after job with id {stageOutJobId} is completed
+                  default: null
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/user/origin
+                targetPath: /home/user/destination
+                jobName: mv-firecrest-job
+                stageOutJobId: "123456"
+                time: "2-03:00:00"
       responses:
-        '200':
-          description: operation queued. Job Id returned.
+        '201':
+          description: operation queued. Task Id returned.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                description: Job id
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access paths
@@ -1039,8 +1428,8 @@ paths:
               description: sourcePath and/or targetPath are invalid paths.
               schema:
                 type: integer
-  /storage/xfer-internal/cp:
-    get:
+  '/storage/xfer-internal/cp':
+    post:
       summary: copy files and directories
       description: >-
         'Copy files and directories between internal CSCS file systems. Copy
@@ -1050,56 +1439,58 @@ paths:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
       tags:
         - Storage
-      parameters:
-        - name: sourcePath
-          in: query
-          description: source path to the filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: targetPath
-          in: query
-          description: target path to the filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: jobName
-          in: query
-          description: job name the operation
-          schema:
-            type: string
-        - name: time
-          in: query
-          description: >-
-            'Limit on the total run time of the rsync. Acceptable time formats 
-            \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
-            \'days-hours\', \'days-hours:minutes\' and
-            \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
-            xfer job.'
-          schema:
-            type: string
-            default: '02:00:00'
-        - name: stageOutJobId
-          in: query
-          description: Perform operation after job with id 'stageOutJobId' is completed
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: source path to the location filesystem
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                jobName:
+                  type: string
+                  description: job name the copy operation
+                  default: cp-job
+                time:
+                  type: string
+                  description: >-
+                    'Limit on the total run time of the copy. Acceptable time formats
+                    \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
+                    \'days-hours\', \'days-hours:minutes\' and
+                    \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
+                    xfer job.'
+                  default: '02:00:00'
+                stageOutJobId:
+                  type: string
+                  description: Copy data after job with id {stageOutJobId} is completed
+                  default: null
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/user/origin
+                targetPath: /home/user/destination
+                jobName: cp-firecrest-job
+                stageOutJobId: "123456"
+                time: "2-03:00:00"
       responses:
-        '200':
-          description: operation queued. Job Id returned.
+        '201':
+          description: operation queued. Task Id returned.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                description: Job id
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access paths
@@ -1117,8 +1508,8 @@ paths:
               description: sourcePath and/or targetPath are invalid paths.
               schema:
                 type: integer
-  /storage/xfer-internal/rm:
-    get:
+  '/storage/xfer-internal/rm':
+    post:
       summary: remove files or directories
       description: >-
         'Remove files or directories in the internal CSCS file systems, with
@@ -1128,49 +1519,53 @@ paths:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
       tags:
         - Storage
-      parameters:
-        - name: targetPath
-          in: query
-          description: target path to the filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
-        - name: jobName
-          in: query
-          description: job name the operation
-          schema:
-            type: string
-        - name: time
-          in: query
-          description: >-
-            'Limit on the total run time of the rsync. Acceptable time formats 
-            \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
-            \'days-hours\', \'days-hours:minutes\' and
-            \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
-            xfer job.'
-          schema:
-            type: string
-            default: '02:00:00'
-        - name: stageOutJobId
-          in: query
-          description: Perform operation after job with id 'stageOutJobId' is completed
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+                jobName:
+                  type: string
+                  description: job name the remove operation
+                  default: rm-job
+                time:
+                  type: string
+                  description: >-
+                    'Limit on the total run time of the rm. Acceptable time formats
+                    \'minutes\',   \'minutes:seconds\',   \'hours:minutes:seconds\',
+                    \'days-hours\', \'days-hours:minutes\' and
+                    \'days-hours:minutes:seconds\'. Note: for stage-in queue a slurm
+                    xfer job.'
+                  default: '02:00:00'
+                stageOutJobId:
+                  type: string
+                  description: Delete data after job with id {stageOutJobId} is completed
+                  default: null
+              required:
+                - targetPath
+              example:
+                targetPath: /home/user/file-to-delete
+                jobName: rm-firecrest-job
+                stageOutJobId: "123456"
+                time: "2-03:00:00"
       responses:
-        '200':
-          description: operation queued. Job Id returned.
+        '201':
+          description: operation queued. Task Id returned.
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                description: Job id
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access paths
@@ -1184,8 +1579,8 @@ paths:
               description: targetPath is an invalid path.
               schema:
                 type: integer
-  /storage/xfer-external/upload:
-    get:
+  '/storage/xfer-external/upload':
+    post:
       summary: Upload a file
       description: >-
         Starts an asynchronous upload to a specific path, the upload workflow is
@@ -1193,27 +1588,42 @@ paths:
         task that will provide a persisten URL at which the target file can be
         uploaded to, the persistent URL is encoded with a random hash and is
         available for an extended period of time (it does not depend on the
-        lifetime of the OIDC token). Once the file has been uploaded to the file server, user must call /upload-finished with task id provided by Task microservice.
-        
+        lifetime of the OIDC token).
+
       tags:
         - Storage
-      parameters:
-        - name: targetPath
-          in: query
-          description: target path to the filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: source path to the file in local machine
+                targetPath:
+                  type: string
+                  description: Absolute path to destination
+              required:
+                - sourcePath
+                - targetPath
+              example:
+                sourcePath: /home/local_user/origin
+                targetPath: /home/user/destination
       responses:
-        '300':
-          description: operation queued.
+        '201':
+          description: operation queued. Task Id returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access path
@@ -1227,30 +1637,16 @@ paths:
               description: targetPath is an invalid path.
               schema:
                 type: integer
-  /storage/xfer-external/upload-finished/{task_id}:
-    get:
-      summary: Upload to Object Storage finished notification
-      description: >-
-        Once upload to file server has completed, user must notify this to Storage microservice in order to move file to targetPath.
-      tags:
-        - Storage
-      parameters:
-        - name: task_id
-          in: path
-          description: id of related task created on upload
-          required: true
-          schema:
-            type: string
-      responses:
-        '404':
-          description: task_id not found
-        '400':
-          description: object does not exist on file server.
-        '200':
-          description: object start to move to targetPath
-        
-  /storage/xfer-external/download:
-    get:
+            X-Not-A-Directory:
+              description: targetPath is not a directory
+              schema:
+                type: string
+            X-Error:
+              description: Error
+              schema:
+                type: string
+  '/storage/xfer-external/download':
+    post:
       summary: Download a file
       description: >-
         Start an asynchronous download by creating a new task in the Tasks
@@ -1261,88 +1657,291 @@ paths:
         the lifetime of the OIDC token).
       tags:
         - Storage
-      parameters:
-        - name: sourcePath
-          in: query
-          description: source path to the filesystem
-          required: true
-          schema:
-            type: string
-          allowReserved: true
+      requestBody:
+        required: true
+        content:
+          'multipart/form-data':
+            schema:
+              type: object
+              properties:
+                sourcePath:
+                  type: string
+                  description: source path to the file in remote filesystem
+              required:
+                - sourcePath
+              example:
+                sourcePath: /home/user/file
       responses:
-        '300':
-          description: operation queued.
+        '201':
+          description: operation queued. Task Id returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-ok'
         '400':
           description: Error on operation
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/Upload-notok'
           headers:
             X-Permission-Denied:
               description: User does not have permissions to access path
               schema:
-                type: integer
+                type: string
             X-Not-Found:
               description: targetPath not found
               schema:
-                type: integer
+                type: string
             X-Invalid-Path:
               description: targetPath is an invalid path.
               schema:
-                type: integer
-  /tasks/tasks:
+                type: string
+            X-A-Directory:
+              description: targetPath is a directory, can't download directories
+              schema:
+                type: string
+            X-Error:
+              description: Error
+              schema:
+                type: string
+  '/storage/xfer-external/invalidate':
+    post:
+      summary: Invalidate temporary URL
+      description: >-
+        Remove a temporary URL attached to a given Task Id
+      tags:
+        - Storage
+      parameters:
+        - in: header
+          name: X-Task-Id
+          description: Task Id associated to the upload/download task
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: operation queued. Task Id returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invalidate-ok'
+        '400':
+          description: Error on operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upload-notok'
+  '/tasks':
     get:
-      summary: returns all tasks
-      description: List all recorded tasks and their status
+      summary: Returns all tasks
+      description: List all recorded tasks and their status.
       tags:
         - Tasks
       responses:
         '200':
           description: tasks in queue
-    put:
-      summary: Creates a task
-      description: Create a new task entry to keep track and link to resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tasks'
+    post:
+      summary: Creates a new task
+      description: Creates a new task.
+      parameters:         
+      - in: header
+        name: X-Firecrest-Service
+        description: Name of the service for which the task will be created ("compute" or "storage")
+        required: true
+        schema:
+          type: string
       tags:
         - Tasks
-      responses:
-        '200':
-          description: task id
-  '/tasks/tasks/{id}':
+      responses:        
+        '201':
+          description: Task created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task-Post-Ok'
+        '400':
+          description: Error creating task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-400'
+        '401':
+          description: Not authorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-400'
+        '403':
+          description: Parameters error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-403'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-404'
+  '/tasks/{taskid}':
     parameters:
-      - name: id
+      - name: taskid
         in: path
         description: id of task
         required: true
         schema:
           type: string
     get:
-      summary: task status information
-      description: A long running task progress and result is tracked through a task id
+      summary: Task status information
+      description: A long running task progress and result is tracked through a {taskid}.
       tags:
         - Tasks
       responses:
         '200':
           description: task in Tasks
-    post:
-      summary: Updates a task
-      description: Updates a task entry that keeps track of progress
-      tags:
-        - Tasks
-      responses:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+    
+    put:
+     summary: Updates a task
+     description: Updates a task entry that keeps track of progress
+     parameters:         
+      - in: header
+        name: X-Firecrest-Service
+        description: Name of the service for which the task will be created ("compute"/"storage")
+        required: true
+        schema:
+          type: string
+     tags:
+       - Tasks
+     responses:
         '200':
-          description: created task
-    delete:
-      summary: Delete task
-      description: Delete a already existing task
-      tags:
-        - Tasks
-      responses:
-        '200':
-          description: Task deleted
+          description: Task updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-ok'
         '400':
-          description: Failed to delete task
+          description: Error updating task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-400'
+        '403':
+          description: Parameters error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-403'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-404'
+    delete:
+     summary: Delete task
+     description: Delete a already existing task
+     tags:
+       - Tasks
+     responses:
+        '204':
+          description: Task deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-ok'
+        '400':
+          description: Error deleting task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-400'
+        '403':
+          description: Parameters error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-403'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-404'
+
+  '/tasks/expire/{task_id}':
+    post:
+      summary: Marks tasks with an expiration time
+      description: Marks tasks with an expiration time. After that the tasks will be removed.
+      tags:
+        - Tasks
+      responses:
+        '200':
+          description: Task marked for expiration successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-ok'
+        '400':
+          description: Error marking task for expiration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-400'
+        '403':
+          description: Parameters error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-403'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expiration-404'
+
+        
+
+    
+
+
+  '/certificator':
+    post:
+      summary: Creates SSH certificates
+      description: creates an SSH certificate to be used for system command execution
+      tags:
+        - 'Certificator'
+      responses:
+        '200':
+          description: certificate created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificator-ok'
+
+        '404':
+          description: Error creating certificate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificator-notok'
+        
+
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT    # optional, arbitrary value for documentation purposes
   parameters:
     machinename:
       name: machineName
@@ -1437,6 +2036,18 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/System'
+    Parameters:
+      type: object
+      properties:
+        microservice-name:
+          type: object
+          properties:
+            name:
+              type: string
+            value:
+              type: string
+            unit:
+              type: string
     Error:
       properties:
         code:
@@ -1448,8 +2059,6 @@ components:
         - service
       properties:
         service:
-          type: string
-        endpoint:
           type: string
         status:
           type: string
@@ -1487,10 +2096,59 @@ components:
           type: string
         nodelist:
           type: string
+    Certificator-ok:
+      type: object
+      properties:
+          certificate:
+            type: string
+            description: SSH certificate
+    Certificator-notok:
+      type: object
+      properties:
+          description:
+            type: string
+            description: Error description.
+          error:
+            type: string
+            description: Error description.
+    Expiration-ok:
+      type: object
+      properties:
+        success:
+          type: string
+          description: Success description    
+    Expiration-400:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error description           
+    Expiration-403:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Operation not permitted
+    Expiration-404:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Task not found
+    Task-Post-Ok:
+      type: object
+      properties:
+          hash_id:
+            type: string
+            description: unique task ID
+          task_url:
+            type: string
+            description: URL for querying the task
+
     Jobs:
       type: array
       items:
-        $ref: '#/components/schemas/job'
+        $ref: '#/components/schemas/Job'
     Session:
       properties:
         authenticated:
@@ -1512,6 +2170,63 @@ components:
         stderr:
           type: string
           description: Standard error returned by application.
+    Task:
+      type: object
+      required:
+        - hash_id
+      properties:
+        hash_id:
+          type: string
+        description:
+          type: string
+        data:
+          type: object
+        last_modify:
+          type: string
+        user:
+          type: string
+        status:
+          type: string
+        service:
+          type: string
+        task_url:
+          type: string
+    Tasks:
+      type: array
+      items:
+        $ref: '#/components/schemas/Task'
+    Upload-ok:
+      type: object
+      properties:
+        success:
+          type: string
+        task_url:
+          type: string
+        task_id:
+          type: string
+    Upload-notok:
+      type: object
+      properties:
+        error:
+          type: string
+    Utilities-ok:
+      type: object
+      properties:
+        description:
+          type: string
+        output:
+          type: string
+    Utilities-notok:
+      type: object
+      properties:
+        description:
+          type: string
+        error:
+    Invalidate-ok:
+      type: object
+      properties:
+        success:
+          type: string
 tags:
   - name: Status
     description: Status information of infrastructure and services.
@@ -1531,3 +2246,5 @@ tags:
       state of the request.
   - name: Tasks
     description: Access status and response of compute and storage tasks.
+security:
+  - bearerAuth: []

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -97,6 +97,17 @@ class AsyncTask():
             self.data = data
         self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
 
+    # return status for internal info (returns SSH "cert"ificate or "action")
+    def get_internal_status(self):
+
+        return {"hash_id":self.hash_id,
+                "user": self.user,
+                "status":self.status_code,
+                "description":self.status_desc,                
+                "data": self.data,
+                "service":self.service,
+                "last_modify":self.timestamp}
+
     # return status for public info, so task_id is discarded
     def get_status(self):
 

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -274,14 +274,14 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
         
 	# poll process status since directly using recv_exit_status() could result
         # in a permanent hang when remote output is larger than the current Transport or session’s window_size 
-        for i in range(0,10):
+        while True:
             if stderr.channel.exit_status_ready():
                 logging.info("stderr channel exit status ready") 
                 stderr_errno = stderr.channel.recv_exit_status()
                 endtime = time.time() + 30
                 eof_received = True
                 while not stderr.channel.eof_received:
-                    time.sleep(1)
+                    # time.sleep(0.5)
                     if time.time() > endtime:
                         stderr.channel.close()
                         eof_received = False
@@ -292,17 +292,18 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
                     # clean "tput: No ..." lines at error output
                     stderr_errda = clean_err_output(error)
                 break
-            else:
-                time.sleep(5)
+            # else:
+            #     time.sleep(5)
 
-        for i in range(0,10):
+        #for i in range(0,10):
+        while True:
             if stdout.channel.exit_status_ready():
                 logging.info("stdout channel exit status ready") 
                 stdout_errno = stdout.channel.recv_exit_status()
                 endtime = time.time() + 30
                 eof_received = True
                 while not stdout.channel.eof_received:
-                    time.sleep(1)
+                    # time.sleep(0.5)
                     if time.time() > endtime:
                         stdout.channel.close()
                         eof_received = False
@@ -313,8 +314,8 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
                     # clean "tput: No ..." lines at error output
                     stdout_errda = clean_err_output(output)
                 break
-            else:
-                time.sleep(5)
+            # else:
+            #     time.sleep(5)
 
 
         if file_transfer == "download":

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -451,35 +451,42 @@ def create_task(auth_header,service=None):
 
 
 # function to call update task entry API in Queue FS
-def update_task(task_id, auth_header, status, msg = None, is_json=False):
+def update_task(task_id, auth_header, service, status, msg = None, is_json=False):
 
-    logging.info(f"{TASKS_URL}/{task_id}")
+    logging.info(f"Update {TASKS_URL}/{task_id}")
 
     if is_json:
         data = {"status": status, "msg": msg}
         req = requests.put(f"{TASKS_URL}/{task_id}",
-                            json=data, headers={AUTH_HEADER_NAME: auth_header})
+                            json=data, headers={AUTH_HEADER_NAME: auth_header, "X-Firecrest-Service":service})
     else:
         data = {"status": status, "msg": msg}
         req = requests.put(f"{TASKS_URL}/{task_id}",
-                            data=data, headers={AUTH_HEADER_NAME: auth_header})
+                            data=data, headers={AUTH_HEADER_NAME: auth_header, "X-Firecrest-Service":service})
 
     resp = json.loads(req.content)
 
     return resp
 
 # function to call update task entry API in Queue FS
-def expire_task(task_id,auth_header):
+def expire_task(task_id,auth_header,service):
 
-    logging.info(f"{TASKS_URL}/task-expire/{task_id}")
+    logging.info(f"{TASKS_URL}/expire/{task_id}")
 
 
-    req = requests.post(f"{TASKS_URL}/task-expire/{task_id}",
-                            headers={AUTH_HEADER_NAME: auth_header})
+    req = requests.post(f"{TASKS_URL}/expire/{task_id}",
+                            headers={AUTH_HEADER_NAME: auth_header, "X-Firecrest-Service": service})
 
-    resp = json.loads(req.content)
+    # resp = json.loads(req.content)
 
-    return resp
+    if not req.ok:
+        logging.info(req.json())
+        return False
+
+    return True
+
+    
+    
 
 # function to check task status:
 def get_task_status(task_id,auth_header):

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -298,7 +298,7 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
         error_str = res["msg"]
         if in_str(error_str,"OPENSSH"):
             error_str = "User does not have permissions to access machine"
-        msg += error_str
+        msg = f"{msg}. {error_str}"
 
         app.logger.error(msg)
         update_task(task_id, auth_header, async_task.ST_UPL_ERR, msg)

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -144,8 +144,11 @@ def os_to_fs(task_id):
     username = upl_file["user"]
     objectname = upl_file["source"]
 
+
     try:
+
         action = upl_file["msg"]["action"]
+        
         # certificate is encrypted with CERT_CIPHER_KEY key
         # here is decrypted
         cert = upl_file["msg"]["cert"]
@@ -176,14 +179,14 @@ def os_to_fs(task_id):
         cert_list = [f"{td}/user-key-cert.pub", f"{td}/user-key.pub", f"{td}/user-key", td]
 
         # start download from OS to FS
-        update_task(task_id,None,async_task.ST_DWN_BEG)
+        update_task(task_id,None,"storage",async_task.ST_DWN_BEG)
 
         # execute download
         result = exec_remote_command(username, system_name, system_addr, "", "storage_cert", cert_list)
 
         # if no error, then download is complete
         if result["error"] == 0:
-            update_task(task_id, None, async_task.ST_DWN_END)
+            update_task(task_id, None,"storage", async_task.ST_DWN_END)
             # delete upload request
             del uploaded_files[task_id]
 
@@ -195,7 +198,7 @@ def os_to_fs(task_id):
             app.logger.error(result["msg"])
             upl_file["status"] = async_task.ST_DWN_ERR
             uploaded_files[task_id] = upl_file
-            update_task(task_id,None,async_task.ST_DWN_ERR,result["msg"])
+            update_task(task_id,None,"storage",async_task.ST_DWN_ERR,result["msg"])
 
     except Exception as e:
         app.logger.error(e)
@@ -207,6 +210,11 @@ def check_upload_files():
     global staging
 
     while True:
+        
+        # Get updated task status from Tasks microservice DB backend (TaskPersistence)
+        get_upload_unfinished_tasks()
+
+        # Timestampo for logs
         timestamp = time.asctime( time.localtime(time.time()) )
         
         app.logger.info(f"Check files in Object Storage {timestamp}")
@@ -230,6 +238,8 @@ def check_upload_files():
                     app.logger.info(f"Task {task_id} -> File ready to upload or already downloaded")
 
                     upl = uploaded_files[task_id]
+                    app.logger.info(upl)
+
                     containername = upl["user"]
                     prefix = task_id
                     objectname = upl["source"]
@@ -239,8 +249,27 @@ def check_upload_files():
                         continue
 
                     # confirms that file is in OS (auth_header is not needed)
-                    update_task(task_id, None, async_task.ST_UPL_CFM)
+                    update_task(task_id, None, "storage",async_task.ST_UPL_CFM)
                     upload["status"] = async_task.ST_UPL_CFM
+                    uploaded_files["task_id"] = upload
+                    os_to_fs_task = threading.Thread(target=os_to_fs,args=(task_id,))
+                    os_to_fs_task.start()
+                # if the upload to OS is done but the download to FS failed, then resume
+                elif upload["status"] == async_task.ST_DWN_ERR:
+                    upl = uploaded_files[task_id]
+                    containername = upl["user"]
+                    prefix = task_id
+                    objectname = upl["source"]
+                    # if file has been deleted from OS, then erroneous upload process. Restart.
+                    if not staging.is_object_created(containername,prefix,objectname):
+                        app.logger.info(f"{containername}/{prefix}/{objectname} isn't created in staging area, task marked as erroneous")
+                        update_task(task_id, None, "storage",async_task.ERROR, "File was deleted from staging area. Start a new upload process")
+                        upload["status"] = async_task.ERROR
+                        continue
+
+                    # if file is still in OS, proceed to new download to FS
+                    update_task(task_id, None, "storage",async_task.ST_DWN_BEG)
+                    upload["status"] = async_task.ST_DWN_BEG
                     uploaded_files["task_id"] = upload
                     os_to_fs_task = threading.Thread(target=os_to_fs,args=(task_id,))
                     os_to_fs_task.start()
@@ -266,7 +295,7 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
     if not staging.is_token_valid():
         if not staging.authenticate():
             msg = "Staging area auth error"
-            update_task(task_id, auth_header, async_task.ERROR, msg)
+            update_task(task_id, auth_header,"storage", async_task.ERROR, msg)
             return
 
     # create container if it doesn't exists:
@@ -277,7 +306,7 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
 
         if errno == -1:
             msg="Could not create container {container_name} in Staging Area ({staging_name})".format(container_name=container_name, staging_name=staging.get_object_storage())
-            update_task(task_id, auth_header, async_task.ERROR, msg)
+            update_task(task_id, auth_header,"storage", async_task.ERROR, msg)
             return
 
     # upload file to swift
@@ -286,7 +315,7 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
     upload_url = staging.create_upload_form(sourcePath, container_name, object_prefix, STORAGE_TEMPURL_EXP_TIME, STORAGE_MAX_FILE_SIZE)
 
     # advice Tasks that upload begins:
-    update_task(task_id, auth_header, async_task.ST_UPL_BEG)
+    update_task(task_id, auth_header,"storage", async_task.ST_UPL_BEG)
 
     # upload starts:
     res = exec_remote_command(auth_header,system_name, system_addr,upload_url["command"])
@@ -301,7 +330,7 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
         msg = f"{msg}. {error_str}"
 
         app.logger.error(msg)
-        update_task(task_id, auth_header, async_task.ST_UPL_ERR, msg)
+        update_task(task_id, auth_header, "storage",async_task.ST_UPL_ERR, msg)
         return
 
 
@@ -312,11 +341,11 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
     # if error raises in temp url creation:
     if temp_url == None:
         msg = "Temp URL creation failed. Object: {object_name}".format(object_name=object_name)
-        update_task(task_id, auth_header, async_task.ERROR, msg)
+        update_task(task_id, auth_header,"storage", async_task.ERROR, msg)
         return
 
     # if succesfully created: temp_url in task with success status
-    update_task(task_id, auth_header,async_task.ST_UPL_END, temp_url)
+    update_task(task_id, auth_header,"storage",async_task.ST_UPL_END, temp_url)
     retval = staging.delete_object_after(containername=container_name,prefix=object_prefix,objectname=object_name,ttl=STORAGE_TEMPURL_EXP_TIME)
 
     if retval == 0:
@@ -356,7 +385,7 @@ def download_request():
     if task_id == -1:
         data = jsonify(error="Couldn't create task")
         return data, 400
-
+    
     # asynchronous task creation
     aTask = threading.Thread(target=download_task,
                              args=(auth_header, system_name, system_addr, sourcePath, task_id))
@@ -364,7 +393,7 @@ def download_request():
     storage_tasks[task_id] = aTask
 
     try:
-        update_task(task_id, auth_header, async_task.QUEUED)
+        update_task(task_id, auth_header,"storage", async_task.QUEUED)
 
         storage_tasks[task_id].start()
 
@@ -446,7 +475,7 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
     data["msg"] = "Waiting for Presigned URL to upload file to staging area ({})".format(staging.get_object_storage())
 
     # change to dictionary containing upload data (for backup purpouses) and adding url call
-    update_task(task_id, auth_header, async_task.ST_URL_ASK, data, is_json=True)
+    update_task(task_id, auth_header,"storage", async_task.ST_URL_ASK, data, is_json=True)
 
     # check if staging token is valid
     if not staging.is_token_valid():
@@ -455,7 +484,7 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
             msg = "Staging Area auth error, try again later"
             data["msg"] = msg
             data["status"] = async_task.ERROR
-            update_task(task_id, auth_header, async_task.ERROR, data, is_json=True)
+            update_task(task_id, auth_header, "storage",async_task.ERROR, data, is_json=True)
             return
 
 
@@ -468,7 +497,7 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
             msg="Could not create container {container_name} in Staging Area ({staging_name})".format(container_name=container_name, staging_name=staging.get_object_storage())
             data["msg"] = msg
             data["status"] = async_task.ERROR
-            update_task(task_id,auth_header, async_task.ERROR,data,is_json=True)
+            update_task(task_id,auth_header,"storage",async_task.ERROR,data,is_json=True)
             return
 
     object_prefix = task_id
@@ -494,7 +523,7 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
         app.logger.error(msg)
         data["msg"] = msg
         data["status"] = async_task.ERROR
-        update_task(task_id,auth_header,async_task.ERROR,data,is_json=True)
+        update_task(task_id,auth_header,"storage",async_task.ERROR,data,is_json=True)
         return
 
     # converts file to string to store in Tasks
@@ -518,10 +547,8 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
     data["status"] = async_task.ST_URL_REC
 
     app.logger.info("Cert and url created correctly")
-    # app.logger.info(download_url)
-    # app.logger.info(certs)
-
-    update_task(task_id,auth_header,async_task.ST_URL_REC,data,is_json=True)
+    
+    update_task(task_id,auth_header,"storage",async_task.ST_URL_REC,data,is_json=True)
 
     return
 
@@ -565,10 +592,11 @@ def upload_request():
 
     if task_id == -1:
         return jsonify(error="Error creating task"), 400
+   
 
     # asynchronous task creation
     try:
-        update_task(task_id, auth_header, async_task.QUEUED)
+        update_task(task_id, auth_header, "storage",async_task.QUEUED)
 
         aTask = threading.Thread(target=upload_task,
                              args=(auth_header,system_name, system_addr,targetPath,sourcePath,task_id))
@@ -613,7 +641,7 @@ def upload_finished_task(auth_header, system_name, system_addr, targetPath, sour
     if not staging.is_token_valid():
         if not staging.authenticate():
             msg = "Staging area auth error"
-            update_task(hash_id, auth_header, async_task.ERROR, msg)
+            update_task(hash_id, auth_header,"storage", async_task.ERROR, msg)
             return
 
 
@@ -637,14 +665,14 @@ def upload_finished_task(auth_header, system_name, system_addr, targetPath, sour
     if temp_url==None:
         msg = "Error in download temp URL creation, try again later"
         data["msg"] = msg
-        update_task(hash_id, auth_header, async_task.ST_DWN_ERR,data,is_json=True)
+        update_task(hash_id, auth_header, "storage",async_task.ST_DWN_ERR,data,is_json=True)
         return
 
     app.logger.info("[TASK_ID: {task_id}] Temp URL: {tempUrl}".format(task_id=hash_id,tempUrl=temp_url))
     data = uploaded_files[hash_id]
 
     # register download to server started
-    update_task(hash_id,auth_header, async_task.ST_DWN_BEG, data, is_json=True)
+    update_task(hash_id,auth_header,"storage", async_task.ST_DWN_BEG, data, is_json=True)
     res = get_file_from_storage(auth_header,system_name, system_addr,targetPath,temp_url,sourcePath) #download file to system
 
     # result {"error": "error_msg"}
@@ -654,12 +682,12 @@ def upload_finished_task(auth_header, system_name, system_addr, targetPath, sour
         app.logger.error(res["msg"])
         msg = res["msg"]
         data["msg"] = msg
-        update_task(hash_id,auth_header,async_task.ST_DWN_ERR, data, is_json=True)
+        update_task(hash_id,auth_header,"storage",async_task.ST_DWN_ERR, data, is_json=True)
         #return jsonify(error=res["msg"])
 
     else:
         # update task with success signal
-        update_task(hash_id, auth_header,async_task.ST_DWN_END,data,is_json=True)
+        update_task(hash_id, auth_header,"storage",async_task.ST_DWN_END,data,is_json=True)
 
         # delete upload request
         del uploaded_files[hash_id]
@@ -725,7 +753,7 @@ def upload_finished_call(hash_id,auth_header):
         # register change in status, after upload finished confirmed by SWIFT
         # data = uploaded_files[hash_id]
 
-        update_task(hash_id, auth_header, async_task.ST_UPL_CFM, data, is_json=True)
+        update_task(hash_id, auth_header,"storage", async_task.ST_UPL_CFM, data, is_json=True)
 
         # if object is in OS, then starts to download to cluster:
         staging.delete_object_after(containername=user, prefix=hash_id, objectname=sourcePath, ttl=STORAGE_TEMPURL_EXP_TIME)
@@ -741,7 +769,7 @@ def upload_finished_call(hash_id,auth_header):
         data["msg"] = "Starting async task for download to filesystem"
 
         # update_task(hash_id, auth_header, async_task.PROGRESS,"Starting download to File System")
-        update_task(hash_id, auth_header, async_task.ST_DWN_BEG, data, is_json=True)
+        update_task(hash_id, auth_header, "storage",async_task.ST_DWN_BEG, data, is_json=True)
 
         aTask = threading.Thread(target=upload_finished_task,
                                  args=(auth_header,system_name,system_addr,target,sourcePath,hash_id,))
@@ -1021,22 +1049,25 @@ def create_staging():
     else:
         app.logger.warning("No Object Storage for staging area was set.")
 
+def get_upload_unfinished_tasks():
 
-def init_storage():
-    # should check Tasks tasks than belongs to storage
-
-    create_staging()
-
+    # cleanup upload dictionary
+    global uploaded_files
+    uploaded_files = {}
+    
+    
+    app.logger.info("Staging Area Used: {}".format(staging.url))
+    app.logger.info("ObjectStorage Technology: {}".format(staging.get_object_storage()))
+    
     try:
-        app.logger.info("Staging Area Used: {}".format(staging.url))
-        app.logger.info("ObjectStorage Technology: {}".format(staging.get_object_storage()))
-
         # query Tasks microservice for previous tasks. Allow 30 seconds to answer
         retval=requests.get("{tasks_url}/taskslist".format(tasks_url=TASKS_URL), timeout=30)
 
-        if retval.status_code != 200:
+        if not retval.ok:
             app.logger.error("Error getting tasks from Tasks microservice")
-            return False
+            app.logger.warning("TASKS microservice is down")
+            app.logger.warning("STORAGE microservice will not be fully functional")
+            return
 
         queue_tasks = retval.json()
 
@@ -1064,9 +1095,9 @@ def init_storage():
 
                 if task["status"] == async_task.ST_DWN_BEG:
                     task["status"] = async_task.ST_DWN_ERR
-                    task["description"] = "Storage has been restarted, restart upload-finished"
+                    task["description"] = "Storage has been restarted, process will be resumed"
 
-                    update_task(task["hash_id"], "", async_task.ST_DWN_ERR, data, is_json=True)
+                    update_task(task["hash_id"], "","storage", async_task.ST_DWN_ERR, data, is_json=True)
 
                 uploaded_files[task["hash_id"]] = data
 
@@ -1083,13 +1114,20 @@ def init_storage():
                 app.logger.error(e)
                 app.logger.error(type(e))
 
-        app.logger.info("Tasks saved: {n}".format(n=n_tasks))
+            app.logger.info("Tasks saved: {n}".format(n=n_tasks))
 
-        
     except Exception as e:
         app.logger.warning("TASKS microservice is down")
         app.logger.warning("STORAGE microservice will not be fully functional")
         app.logger.error(e)
+
+
+def init_storage():
+    # should check Tasks tasks than belongs to storage
+
+    create_staging()
+    get_upload_unfinished_tasks()
+    
 
 
 if __name__ == "__main__":

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -484,7 +484,8 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
     # create certificate for later download from OS to filesystem
     app.logger.info("Creating certificate for later download") 
     options = f"-q -O {targetPath}/{fileName} -- '{download_url}'"
-    certs = create_certificate(auth_header, system_name, system_addr, "wget", options)
+    exp_time = STORAGE_TEMPURL_EXP_TIME
+    certs = create_certificate(auth_header, system_name, system_addr, "wget", options, exp_time)
     # certs = create_certificates(auth_header,system,command="wget",options=urllib.parse.quote(options),exp_time=STORAGE_TEMPURL_EXP_TIME)
 
     if not certs[0]:

--- a/src/tests/automated_tests/unit/test_unit_tasks.py
+++ b/src/tests/automated_tests/unit/test_unit_tasks.py
@@ -144,7 +144,7 @@ def test_delete_task_id_not_exists(headers):
 def test_expire_task(headers):
 	resp = create_task(headers)
 	hash_id = resp.json()["hash_id"]
-	url = "{}/task-expire/{}".format(TASKS_URL, hash_id)
+	url = "{}/expire/{}".format(TASKS_URL, hash_id)
 	resp = requests.post(url, headers=headers)
 	assert resp.status_code == 200 and "success" in resp.json()
 
@@ -153,7 +153,7 @@ def test_expire_task(headers):
 @host_environment_test
 def test_expire_task_id_not_exists(headers):
 	hash_id = "IDONTEXIST"
-	url = "{}/task-expire/{}".format(TASKS_URL, hash_id)
+	url = "{}/expire/{}".format(TASKS_URL, hash_id)
 	resp = requests.post(url, headers=headers)
 	assert resp.status_code == 404 and "error" in resp.json()
 


### PR DESCRIPTION
Several changes:
- Issues
  - At some point when created certificates for 'wget' on upload the `exp_time` var was missing, now added again.
  - removed `sleep` delays in paramiko (on large downloads that take more than 5 mins ~ >50GB, it always gave timeout error)

- Changes:
  - Added expiration in all tasks created: 
    - New environment vars for expiration time depending of the microservice.
    - Using `redis.setex` instead of `redis.set`, since `set` removes the TTL for expiration.
    - Adapted `update_task` in `cscs_api_common.py` to receive microservice name to change expiration time.
    - changed endpoint `/task-expire` for `/expire` in 'Tasks' microservice (evaluating to remove it in the future).
    - Pending uploads now are checked directly from redis (`TaskPersistance`)
