### PR TITLE
Restapi 595 check source and target path on storage xfer internal operations

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -94,7 +94,7 @@ F7T_UTILITIES_MAX_FILE_SIZE=5
 F7T_UTILITIES_TIMEOUT=5
 #------
 # if enabled FirecREST sends a certificate as command, requires a serverside ssh ForceCommand wrapper
-#F7T_SSH_CERTIFICATE_WRAPPER=
+F7T_SSH_CERTIFICATE_WRAPPER=True
 #------
 # KONG internal URLs for services
 F7T_KONG_COMPUTE_URL=http://192.168.220.9:5006

--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -82,8 +82,12 @@ RUN chmod 555 /ssh_command_wrapper.sh
 RUN mkdir /srv/f7t
 ADD cluster/test_sbatch.sh /srv/f7t/.
 ADD cluster/test_sbatch.sh /srv/f7t/test_sbatch_forbidden.sh
+ADD cluster/test_sbatch.sh /srv/f7t/test_sbatch_rm.sh
+ADD cluster/test_sbatch.sh /srv/f7t/test_sbatch_mv.sh
 RUN chmod 777 /srv/f7t
 RUN chmod 555 /srv/f7t/test_sbatch.sh
+RUN chmod 777 /srv/f7t/test_sbatch_rm.sh
+RUN chmod 777 /srv/f7t/test_sbatch_mv.sh
 RUN chmod 700 /srv/f7t/test_sbatch_forbidden.sh
 
 ENTRYPOINT ["/usr/bin/supervisord"]

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -63,7 +63,7 @@ case "$command" in
   sacct|sbatch|scancel|scontrol|squeue)
     # valid Slurm commands
     ;;
-  wget)
+  /usr/bin/wget|curl)
     # from object storage
     ;;
   *)

--- a/deploy/test-build/cluster/ssh/sshd_config
+++ b/deploy/test-build/cluster/ssh/sshd_config
@@ -107,6 +107,6 @@ Subsystem       sftp    /usr/libexec/openssh/sftp-server
     #AllowUsers user1
     MaxAuthTries 1
     AllowTcpForwarding no
-    #ForceCommand /ssh_command_wrapper.sh
+    ForceCommand /ssh_command_wrapper.sh
     PermitTTY no
     PermitTunnel no

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -89,7 +89,7 @@ F7T_UTILITIES_MAX_FILE_SIZE=5
 F7T_UTILITIES_TIMEOUT=5
 #------
 # if enabled FirecREST sends a certificate as command, requires a serverside ssh ForceCommand wrapper
-#F7T_SSH_CERTIFICATE_WRAPPER=
+F7T_SSH_CERTIFICATE_WRAPPER=True
 #------
 # KONG internal URLs for services
 F7T_KONG_JOBS_URL=

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -77,6 +77,14 @@ def test_internal_rm(headers):
     resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
     assert resp.status_code == 201   
 
+def test_internal_rm_err(headers):
+    # jobName, time, stageOutJobId
+    data = {"targetPath": "/srv/f7t/test_sbatch_forbidden.sh"}
+    
+    url = "{}/xfer-internal/rm".format(STORAGE_URL)
+    resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
+    assert resp.status_code == 400
+
 
 # Test storage microservice status
 @host_environment_test

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -3,10 +3,11 @@ import requests
 import os
 from markers import host_environment_test
 from test_globals import *
+import time
 
 FIRECREST_URL = os.environ.get("FIRECREST_URL")
 if FIRECREST_URL:
-	STORAGE_URL = os.environ.get("FIRECREST_URL") + "/storage"
+	STORAGE_URL = os.environ.get("FIRECREST_URL") + "/storage"    
 else:
     STORAGE_URL = os.environ.get("F7T_STORAGE_URL")
 
@@ -45,16 +46,16 @@ def test_download_dir_not_allowed(headers):
 
 
 def test_internal_cp(headers):
-    # jobName, time, stageOutJobId
-    data = {"sourcePath": USER_HOME + "/testsbatch.sh", "targetPath": USER_HOME + "/testsbatch2.sh"}
+    # jobName, time, stageOutJobId    
+    data = {"sourcePath": "/srv/f7t/test_sbatch.sh", "targetPath": USER_HOME + "/testsbatch2.sh"}
     url = "{}/xfer-internal/cp".format(STORAGE_URL)
     resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
     assert resp.status_code == 201
 
 
-def test_internal_mv(headers):
+def test_internal_mv(headers):    
     # jobName, time, stageOutJobId
-    data = {"sourcePath": USER_HOME + "/testsbatch2.sh", "targetPath": USER_HOME + "/testsbatch3.sh"}
+    data = {"sourcePath": "/srv/f7t/test_sbatch_mv.sh", "targetPath": USER_HOME + "/testsbatch3.sh"}
     url = "{}/xfer-internal/mv".format(STORAGE_URL)
     resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
     assert resp.status_code == 201
@@ -70,7 +71,8 @@ def test_internal_rsync(headers):
 
 def test_internal_rm(headers):
     # jobName, time, stageOutJobId
-    data = {"targetPath": USER_HOME + "/testsbatch3.sh"}
+    data = {"targetPath": "/srv/f7t/test_sbatch_rm.sh"}
+    
     url = "{}/xfer-internal/rm".format(STORAGE_URL)
     resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
     assert resp.status_code == 201   


### PR DESCRIPTION
- For all `storage/xfer-internal` checks that file or directory existence and permissions before creating the task.
- Added files and tests, and modified old ones to adapt to this new feature
- Also, enforcing the use of the SSH wrapper in the test environment (in `common.env` and `sshd_config` file)
