### PR TITLE
Restapi 598 adapt firecrest to use account parameter in slurm job submission

### DIFF
--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -80,6 +80,8 @@ F7T_STORAGE_MAX_FILE_SIZE=5120
 F7T_OBJECT_STORAGE='s3v4'
 # partition for internal transfer
 F7T_XFER_PARTITION=xfer
+# set if account is needed for SLURM job submission
+F7T_USE_SLURM_ACCOUNT=True 
 # machine for external transfers
 F7T_EXT_TRANSFER_MACHINE_PUBLIC='cluster'
 F7T_EXT_TRANSFER_MACHINE_INTERNAL='192.168.220.12:22'

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -52,7 +52,7 @@ case "$command" in
     tmp2=${tmp1#* }
     command2=${tmp2%% *}   # remove options
     case "$command2" in
-      base64|chmod|chown|cp|file|head|ln|ls|mkdir|mv|rm|sbatch|scontrol|sha256sum|squeue|stat|tail|wget)
+      base64|chmod|chown|cp|file|head|id|ln|ls|mkdir|mv|rm|sbatch|scontrol|sha256sum|squeue|stat|tail|wget)
         ;;
       *)
         echo "${msg} error - Unhandled timeout command: ${command2}" >> ${log_file}

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -78,6 +78,8 @@ F7T_STORAGE_TEMPURL_EXP_TIME=604800
 F7T_STORAGE_MAX_FILE_SIZE=512000
 # Storage technology used for staging area (swift or s3v2 or s3v4, unset to disable)
 F7T_OBJECT_STORAGE='s3v4'
+# set if account is needed for SLURM job submission
+F7T_USE_SLURM_ACCOUNT=True 
 #-------
 # STATUS: microservices & systems to pool:
 F7T_STATUS_SERVICES='certificator;utilities;compute;tasks;storage'

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -3,7 +3,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.0.0-RC1
+  version: 1.7.0-beta1
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.
@@ -1309,6 +1309,10 @@ paths:
                   type: string
                   description: Move data after job with id {stageOutJobId} is completed
                   default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  default: null
               required:
                 - sourcePath
                 - targetPath
@@ -1388,6 +1392,10 @@ paths:
                 stageOutJobId:
                   type: string
                   description: Move data after job with id {stageOutJobId} is completed
+                  default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1469,6 +1477,10 @@ paths:
                   type: string
                   description: Copy data after job with id {stageOutJobId} is completed
                   default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  default: null
               required:
                 - sourcePath
                 - targetPath
@@ -1545,6 +1557,10 @@ paths:
                 stageOutJobId:
                   type: string
                   description: Delete data after job with id {stageOutJobId} is completed
+                  default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
                   default: null
               required:
                 - targetPath

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -3,7 +3,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.0.0-RC1
+  version: 1.7.0-beta1
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a
@@ -1321,6 +1321,10 @@ paths:
                   type: string
                   description: Move data after job with id {stageOutJobId} is completed
                   default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  default: null
               required:
                 - sourcePath
                 - targetPath
@@ -1400,6 +1404,10 @@ paths:
                 stageOutJobId:
                   type: string
                   description: Move data after job with id {stageOutJobId} is completed
+                  default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1481,6 +1489,10 @@ paths:
                   type: string
                   description: Copy data after job with id {stageOutJobId} is completed
                   default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  default: null
               required:
                 - sourcePath
                 - targetPath
@@ -1558,6 +1570,10 @@ paths:
                   type: string
                   description: Delete data after job with id {stageOutJobId} is completed
                   default: null
+                account:
+                  type: string
+                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  default: null
               required:
                 - targetPath
               example:
@@ -1616,7 +1632,7 @@ paths:
                   description: source path to the file in local machine
                 targetPath:
                   type: string
-                  description: Absolute path to destination
+                  description: Absolute path to destination                
               required:
                 - sourcePath
                 - targetPath

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -670,7 +670,7 @@ def get_file_from_storage(auth_header,system_name, system_addr,path,download_url
 # jobName = --job-name parameter to be used on sbatch command
 # jobTime = --time  parameter to be used on sbatch command
 # stageOutJobId = value to set in --dependency:afterok parameter
-# account = valute to set in --account parameter
+# account = value to set in --account parameter
 def exec_internal_command(auth_header,command,sourcePath, targetPath, jobName, jobTime, stageOutJobId, account):
 
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -91,6 +91,8 @@ STORAGE_MAX_FILE_SIZE = int(os.environ.get("F7T_STORAGE_MAX_FILE_SIZE", "5120").
 # for use on signature of URL it must be in bytes (MB*1024*1024 = Bytes)
 STORAGE_MAX_FILE_SIZE *= 1024*1024
 
+UTILITIES_TIMEOUT = int(os.environ.get("F7T_UTILITIES_TIMEOUT", "5").strip('\'"'))
+
 STORAGE_POLLING_INTERVAL = int(os.environ.get("F7T_STORAGE_POLLING_INTERVAL", "60").strip('\'"'))
 CERT_CIPHER_KEY = os.environ.get("F7T_CERT_CIPHER_KEY", "").strip('\'"').encode('utf-8')
 
@@ -814,7 +816,7 @@ def internal_operation(request, command):
         if USE_SLURM_ACCOUNT:
             username = get_username(auth_header)
 
-            id_command = f"id -gn -- {username}"
+            id_command = f"timeout {UTILITIES_TIMEOUT} id -gn -- {username}"
             resp = exec_remote_command(auth_header, STORAGE_JOBS_MACHINE, system_addr, id_command)
             if resp["error"] != 0:
                 retval = check_command_error(resp["msg"], resp["error"], f"{command} job")

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -46,7 +46,7 @@ def test_download_dir_not_allowed(headers):
 
 def test_internal_cp(headers):
     # jobName, time, stageOutJobId
-    data = {"sourcePath": USER_HOME + "/testsbatch.sh", "targetPath": USER_HOME + "/testsbatch2.sh"}
+    data = {"sourcePath": USER_HOME + "/testsbatch.sh", "targetPath": USER_HOME + "/testsbatch2.sh", "account": "test"}
     url = "{}/xfer-internal/cp".format(STORAGE_URL)
     resp = requests.post(url, headers=headers,data=data, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
     assert resp.status_code == 201


### PR DESCRIPTION
(`v1.7.0-beta1) Added `account` parameter in `storage/xfer-internal/` API
- For `xfer` queue, because it's the only service that internally creates a sbatch file.
- If `F7T_USE_SLURM_ACCOUNT` is set, and `account` parameter is not supplied, then `id -gn <username>` command is executed and result is used as account
- Added one test passing account name in `unit` test.
- Updated `openapi` specification.