### PR TITLE
Restapi 599 use logger in filter and log script

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+# Contributors
+
+- Cruz, Felipe. ETH Zurich - CSCS
+- Dabin, Alejandro. UNL-CONICET - CIMEC
+- Dorsch, Juan Pablo. ETH Zurich - CSCS
+- Koutsaniti, Eirini. ETH Zurich - CSCS
+- Lezcano, Facundo. UNL-CONICET - CIMEC

--- a/ci/pre-prod/build_image_role.yml
+++ b/ci/pre-prod/build_image_role.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 ---
 - name: Build firecrest microservices images
   hosts: all

--- a/ci/pre-prod/build_image_role/tasks/main.yml
+++ b/ci/pre-prod/build_image_role/tasks/main.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 - name: create build directory
   file:
     path: /home/firecrest/awx-firecrest-build

--- a/ci/pre-prod/build_image_role/vars/main.yml
+++ b/ci/pre-prod/build_image_role/vars/main.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 image_definitions:
   compute:
     build_path: /home/firecrest/awx-firecrest-build

--- a/ci/pre-prod/deploy_demo_playbook.yml
+++ b/ci/pre-prod/deploy_demo_playbook.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 
 ---
 - name: Deploy Firecrest

--- a/ci/pre-prod/provision_test_server.yml
+++ b/ci/pre-prod/provision_test_server.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 ---
 - name: Install docker
   gather_facts: Yes

--- a/ci/pre-prod/remove_demo_containers.yml
+++ b/ci/pre-prod/remove_demo_containers.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 
 
 ---

--- a/ci/pre-prod/run_tests.yml
+++ b/ci/pre-prod/run_tests.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 ---
 - name: Run tests
   gather_facts: no

--- a/ci/pre-prod/save_log_files.yml
+++ b/ci/pre-prod/save_log_files.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 ---
 
 # Log files will be copied from testing server to the logs_dest_dir folder located 

--- a/ci/pre-prod/tag_image_role.yml
+++ b/ci/pre-prod/tag_image_role.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 ---
 - name: tag firecrest microservices images
   hosts: all

--- a/ci/pre-prod/tag_image_role/tasks/main.yml
+++ b/ci/pre-prod/tag_image_role/tasks/main.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 
 - name: Add firecrest-tds tag to firecrest image
   docker_image:

--- a/ci/pre-prod/tag_image_role/vars/main.yml
+++ b/ci/pre-prod/tag_image_role/vars/main.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 image_definitions:
   compute:
   status:

--- a/deploy/demo/demo_client/config.py
+++ b/deploy/demo/demo_client/config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 version: '3.4'
 
 networks:

--- a/deploy/demo/kong/kong.yml
+++ b/deploy/demo/kong/kong.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 _format_version: "1.1"
 
 plugins:

--- a/deploy/demo/source/kong/update_kong_config.sh
+++ b/deploy/demo/source/kong/update_kong_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/deploy/demo/taskpersistence/redis.conf
+++ b/deploy/demo/taskpersistence/redis.conf
@@ -1,3 +1,10 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
 # Redis configuration file example.
 #
 # Note that in order to read the configuration file, Redis must be

--- a/deploy/docker/certificator/Dockerfile
+++ b/deploy/docker/certificator/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 from centos:7
 
 # install epel repo for python-pip package

--- a/deploy/docker/compute/Dockerfile
+++ b/deploy/docker/compute/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 from centos:7
 
 RUN yum install -y epel-release

--- a/deploy/docker/openapi/Dockerfile
+++ b/deploy/docker/openapi/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 FROM swaggerapi/swagger-ui:v3.22.0
 
 COPY doc/openapi/firecrest-developers-api.yaml /tmp/openapi.yaml

--- a/deploy/docker/status/Dockerfile
+++ b/deploy/docker/status/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 FROM centos:7
 
 # install epel repo for python-pip package

--- a/deploy/docker/storage/Dockerfile
+++ b/deploy/docker/storage/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 from centos:7
 
 # install epel repo for python-pip package

--- a/deploy/docker/tasks/Dockerfile
+++ b/deploy/docker/tasks/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 from centos:7
 
 # install epel repo for python-pip package

--- a/deploy/docker/utilities/Dockerfile
+++ b/deploy/docker/utilities/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 from centos:7
 
 # install epel repo for python-pip package

--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -22,6 +22,7 @@ RUN set -ex \
        perl \
        python-pip \
        psmisc \
+       rsyslog \
        wget \
     && yum clean all \
     && rm -rf /var/cache/yum > /dev/null
@@ -77,6 +78,9 @@ RUN /usr/libexec/mariadb-prepare-db-dir 2>/dev/null
 
 ADD cluster/ssh/ssh_command_wrapper.sh /ssh_command_wrapper.sh
 RUN chmod 555 /ssh_command_wrapper.sh
+
+ADD cluster/rsyslog/rsyslog.conf /etc/
+ADD cluster/rsyslog/listen.conf /etc/rsyslog.d
 
 # add sbatch scripts for testing purposes
 RUN mkdir /srv/f7t

--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -1,3 +1,10 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+
 # partially based on https://github.com/giovtorres/slurm-docker-cluster
 
 FROM centos:7

--- a/deploy/test-build/cluster/rsyslog/listen.conf
+++ b/deploy/test-build/cluster/rsyslog/listen.conf
@@ -1,0 +1,7 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+$SystemLogSocketName /dev/log

--- a/deploy/test-build/cluster/rsyslog/rsyslog.conf
+++ b/deploy/test-build/cluster/rsyslog/rsyslog.conf
@@ -1,0 +1,98 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+# The imjournal module bellow is now used as a message source instead of imuxsock.
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad immark  # provides --MARK-- message capability
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+$WorkDirectory /var/lib/rsyslog
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging off
+
+# File to store the position in the journal
+#$IMJournalStateFile imjournal.state
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+# ### end of the forwarding rule ###
+

--- a/deploy/test-build/cluster/slurm/slurm.conf
+++ b/deploy/test-build/cluster/slurm/slurm.conf
@@ -1,3 +1,10 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
 # slurm.conf
 #
 # See the slurm.conf man page for more information.

--- a/deploy/test-build/cluster/slurm/slurmdbd.conf
+++ b/deploy/test-build/cluster/slurm/slurmdbd.conf
@@ -1,3 +1,10 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
 # See the slurmdbd.conf man page for more information.
 # Archive info
 #ArchiveJobs=yes

--- a/deploy/test-build/cluster/slurm/start_db.sh
+++ b/deploy/test-build/cluster/slurm/start_db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/deploy/test-build/cluster/slurm/start_slurmctld.sh
+++ b/deploy/test-build/cluster/slurm/start_slurmctld.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/deploy/test-build/cluster/slurm/start_slurmdbd.sh
+++ b/deploy/test-build/cluster/slurm/start_slurmdbd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
-#
-#  Please, refer to the LICENSE file in the root directory.
-#  SPDX-License-Identifier: BSD-3-Clause
-#
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 
 # Required OpenSSH >= 7.2 for ssh-keygen to read from stdin
 # Optional OpenSSH >= 7.6 for direct access to certificates (via ExposeAuthInfo)

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -18,7 +18,8 @@ SOC="${SSH_ORIGINAL_COMMAND}"
 
 set -u  # -e (abort on command error),  -u (undefined var are errors), -o pipefail (pipe errors)
 
-msg="$(date +%Y-%m-%dT%H:%M:%S) - "${UID}" -"
+# msg="$(date +%Y-%m-%dT%H:%M:%S) - "${UID}" -"
+msg="FirecREST command execution user $USER ($UID) -"
 
 cert_type=${SOC%%-cert-v01@openssh.com *}    # remove all after first space
 
@@ -35,7 +36,7 @@ case "$cert_type" in
     SSH_EXECUTE=${c#*force-command *} # remove " force-command " and spaces
     ;;
   *)
-    echo "${msg} error - Unknown certificate type: $cert_type" >> ${log_file}
+    logger -p user.error "${msg} error - Unknown certificate type: $cert_type"
     exit 118
     ;;
 esac
@@ -55,7 +56,7 @@ case "$command" in
       base64|chmod|chown|cp|curl|id|file|head|ln|ls|mkdir|mv|rm|sbatch|scontrol|sha256sum|squeue|stat|tail)
         ;;
       *)
-        echo "${msg} error - Unhandled timeout command: ${command2}" >> ${log_file}
+        logger -p user.error  "${msg} error - Unhandled timeout command: ${command2}"
         exit 118
         ;;
     esac
@@ -67,13 +68,13 @@ case "$command" in
     # from object storage
     ;;
   *)
-    echo "${msg} error - Unhandled command: ${command}" >> ${log_file}
+    logger -p user.error "${msg} error - Unhandled command: ${command}"
     exit 118
     ;;
 esac
 
 # all ok, log command
-echo "${msg} ok - ${SSH_EXECUTE}" >> ${log_file}
+logger -p user.info "${msg} ok - ${SSH_EXECUTE}"
 
 # execute command
 eval ${SSH_EXECUTE}

--- a/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
+++ b/deploy/test-build/cluster/ssh/ssh_command_wrapper.sh
@@ -30,7 +30,7 @@ case "$cert_type" in
     tmp2=$(grep "^ *${CA_signature}" <<< "$tmp1")
     sig="Signing CA:"${tmp2## *Signing CA:} # remove left spaces
     if [ "$sig" != "$CA_signature" ]; then
-      echo "${msg} error - Wrong CA: ${sig}" >> ${log_file}
+      logger -p user.error "${msg} error - Wrong CA: ${sig}"
       exit 118
     fi
     c=$(grep "^ *force-command " <<< "$tmp1")

--- a/deploy/test-build/cluster/supervisord.conf
+++ b/deploy/test-build/cluster/supervisord.conf
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 [supervisord]
 nodaemon=true
 user=root

--- a/deploy/test-build/cluster/supervisord.conf
+++ b/deploy/test-build/cluster/supervisord.conf
@@ -3,6 +3,8 @@ nodaemon=true
 user=root
 
 
+[program:rsyslog]
+command=/usr/sbin/rsyslogd -n
 
 [program:mariadb]
 command=/usr/bin/mysqld_safe

--- a/deploy/test-build/cluster/test_sbatch.sh
+++ b/deploy/test-build/cluster/test_sbatch.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+
 #SBATCH --job-name=testsbatch
 #SBATCH --ntasks=1
 #SBATCH --tasks-per-node=1

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 version: '3'
 
 services:

--- a/deploy/test-build/taskpersistence/redis.conf
+++ b/deploy/test-build/taskpersistence/redis.conf
@@ -1,3 +1,10 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
 # Redis configuration file example.
 #
 # Note that in order to read the configuration file, Redis must be

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 openapi: 3.0.0
 servers:
   - url: 'http://FIRECREST_URL'

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 openapi: 3.0.0
 servers:
   - url: 'http://FIRECREST_URL'

--- a/src/certificator/certificator.py
+++ b/src/certificator/certificator.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -686,6 +686,10 @@ def check_command_error(error_str, error_code, service_msg):
         header = {"X-Timeout": "Command has finished with timeout signal"}
         return {"description": service_msg, "status_code": 400, "header": header}
 
+    if error_code == 118:
+        header = {"X-Error": "Command execution is not allowed in machine"}
+        return {"description": service_msg, "status_code": 400, "header": header}
+
     # When certificate doesn't match SSH configuration
     if in_str(error_str,"OPENSSH"):
         header = {"X-Permission-Denied": "User does not have permissions to access machine"}

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/common/job_time.py
+++ b/src/common/job_time.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/common/tasks_persistence.py
+++ b/src/common/tasks_persistence.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/status/status.py
+++ b/src/status/status.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/keystone.py
+++ b/src/storage/keystone.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/objectstorage.py
+++ b/src/storage/objectstorage.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/conftest.py
+++ b/src/tests/automated_tests/conftest.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import os
 import jwt

--- a/src/tests/automated_tests/conftest.py
+++ b/src/tests/automated_tests/conftest.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/integration/test_compute.py
+++ b/src/tests/automated_tests/integration/test_compute.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/integration/test_compute.py
+++ b/src/tests/automated_tests/integration/test_compute.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/test_globals.py
+++ b/src/tests/automated_tests/test_globals.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import os
 
 # name of user firing the tests:

--- a/src/tests/automated_tests/test_globals.py
+++ b/src/tests/automated_tests/test_globals.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/testsbatch.sh
+++ b/src/tests/automated_tests/testsbatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/testsbatch.sh
+++ b/src/tests/automated_tests/testsbatch.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+
 #SBATCH --job-name=testsbatch
 #SBATCH --ntasks=1
 #SBATCH --tasks-per-node=1

--- a/src/tests/automated_tests/unit/markers.py
+++ b/src/tests/automated_tests/unit/markers.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import os
 import pytest
 

--- a/src/tests/automated_tests/unit/markers.py
+++ b/src/tests/automated_tests/unit/markers.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_certificator.py
+++ b/src/tests/automated_tests/unit/test_unit_certificator.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/unit/test_unit_certificator.py
+++ b/src/tests/automated_tests/unit/test_unit_certificator.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/unit/test_unit_compute.py
+++ b/src/tests/automated_tests/unit/test_unit_compute.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_status.py
+++ b/src/tests/automated_tests/unit/test_unit_status.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/unit/test_unit_status.py
+++ b/src/tests/automated_tests/unit/test_unit_status.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/unit/test_unit_storage.py
+++ b/src/tests/automated_tests/unit/test_unit_storage.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_tasks.py
+++ b/src/tests/automated_tests/unit/test_unit_tasks.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import json

--- a/src/tests/automated_tests/unit/test_unit_tasks.py
+++ b/src/tests/automated_tests/unit/test_unit_tasks.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/test_unit_utilities.py
+++ b/src/tests/automated_tests/unit/test_unit_utilities.py
@@ -1,3 +1,9 @@
+#
+#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
 import pytest
 import requests
 import os

--- a/src/tests/automated_tests/unit/test_unit_utilities.py
+++ b/src/tests/automated_tests/unit/test_unit_utilities.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/testsbatch.sh
+++ b/src/tests/automated_tests/unit/testsbatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/automated_tests/unit/testsbatch.sh
+++ b/src/tests/automated_tests/unit/testsbatch.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+
 #SBATCH --job-name=testsbatch
 #SBATCH --ntasks=1
 #SBATCH --tasks-per-node=1

--- a/src/tests/template_client/Dockerfile
+++ b/src/tests/template_client/Dockerfile
@@ -1,3 +1,9 @@
+##
+##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 FROM python:3.7-alpine
 
 RUN pip install flask flask-WTF flask-bootstrap flask-oidc flask_sslify requests

--- a/src/tests/template_client/Dockerfile
+++ b/src/tests/template_client/Dockerfile
@@ -1,5 +1,5 @@
 ##
-##  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 ##
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/config.py
+++ b/src/tests/template_client/config.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/firecrest_demo.py
+++ b/src/tests/template_client/firecrest_demo.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/api.html
+++ b/src/tests/template_client/templates/api.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/api.html
+++ b/src/tests/template_client/templates/api.html
@@ -1,3 +1,9 @@
+<!--
+--  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--
+--  Please, refer to the LICENSE file in the root directory.
+--  SPDX-License-Identifier: BSD-3-Clause
+-->
 {% extends "demo_base.html" %}
 {% block title %}Test API{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute.html
+++ b/src/tests/template_client/templates/compute.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/compute.html
+++ b/src/tests/template_client/templates/compute.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Compute microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/acct.html
+++ b/src/tests/template_client/templates/compute/acct.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/compute/acct.html
+++ b/src/tests/template_client/templates/compute/acct.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Accounting information{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/canceljob.html
+++ b/src/tests/template_client/templates/compute/canceljob.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/compute/canceljob.html
+++ b/src/tests/template_client/templates/compute/canceljob.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Cancel compute job{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/job.html
+++ b/src/tests/template_client/templates/compute/job.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/compute/job.html
+++ b/src/tests/template_client/templates/compute/job.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}List single job{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/jobs.html
+++ b/src/tests/template_client/templates/compute/jobs.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/compute/jobs.html
+++ b/src/tests/template_client/templates/compute/jobs.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}List jobs{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/submitjob.html
+++ b/src/tests/template_client/templates/compute/submitjob.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Submit a compute job{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/compute/submitjob.html
+++ b/src/tests/template_client/templates/compute/submitjob.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/demo_base.html
+++ b/src/tests/template_client/templates/demo_base.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/demo_base.html
+++ b/src/tests/template_client/templates/demo_base.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "bootstrap/base.html" %}
 {% import "bootstrap/wtf.html" as wtf %}
 {# {% block head %}

--- a/src/tests/template_client/templates/index.html
+++ b/src/tests/template_client/templates/index.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}FirecREST Demo{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/index.html
+++ b/src/tests/template_client/templates/index.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/status.html
+++ b/src/tests/template_client/templates/status.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/status.html
+++ b/src/tests/template_client/templates/status.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Status microservices{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/status/allservices.html
+++ b/src/tests/template_client/templates/status/allservices.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/status/allservices.html
+++ b/src/tests/template_client/templates/status/allservices.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Status microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/status/allsystems.html
+++ b/src/tests/template_client/templates/status/allsystems.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/status/allsystems.html
+++ b/src/tests/template_client/templates/status/allsystems.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Status microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/status/parameters.html
+++ b/src/tests/template_client/templates/status/parameters.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/status/parameters.html
+++ b/src/tests/template_client/templates/status/parameters.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Status microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/storage.html
+++ b/src/tests/template_client/templates/storage.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Storage microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/storage.html
+++ b/src/tests/template_client/templates/storage.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/storage/download.html
+++ b/src/tests/template_client/templates/storage/download.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/storage/download.html
+++ b/src/tests/template_client/templates/storage/download.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}External File Download{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/storage/upload.html
+++ b/src/tests/template_client/templates/storage/upload.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}External File Upload{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/storage/upload.html
+++ b/src/tests/template_client/templates/storage/upload.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/storage/xfer-internal.html
+++ b/src/tests/template_client/templates/storage/xfer-internal.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/storage/xfer-internal.html
+++ b/src/tests/template_client/templates/storage/xfer-internal.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Create an Internal Transfer Job{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/tasks.html
+++ b/src/tests/template_client/templates/tasks.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/tasks.html
+++ b/src/tests/template_client/templates/tasks.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Tasks microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/tasks/task.html
+++ b/src/tests/template_client/templates/tasks/task.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/tests/template_client/templates/tasks/task.html
+++ b/src/tests/template_client/templates/tasks/task.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}FirecREST Tasks{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/utilities.html
+++ b/src/tests/template_client/templates/utilities.html
@@ -3,7 +3,7 @@
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause
-  -->
+-->
 {% extends "demo_base.html" %}
 {% block title %}Utilities microservice{% endblock %}
 {% block content %}

--- a/src/tests/template_client/templates/utilities.html
+++ b/src/tests/template_client/templates/utilities.html
@@ -1,5 +1,5 @@
 <!--
---  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+--  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 --
 --  Please, refer to the LICENSE file in the root directory.
 --  SPDX-License-Identifier: BSD-3-Clause

--- a/src/utilities/utilities.py
+++ b/src/utilities/utilities.py
@@ -141,7 +141,7 @@ def chmod():
     try:
         mode = request.form["mode"]
         if mode == "":
-            return jsonify(description="Error in chown operation",error="'mode' value is empty"), 400
+            return jsonify(description="Error in chmod operation",error="'mode' value is empty"), 400
     except BadRequestKeyError:
         return jsonify(description="Error in chmod operation", error="mode query string missing"), 400
 

--- a/src/utilities/utilities.py
+++ b/src/utilities/utilities.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019-2020, ETH Zurich. All rights reserved.
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
 #
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
- Log and filter script (`ssh_command_wrapper.sh`) now uses `logger` command to log to `rsyslog` instead of redirecting to a file.
  - `rsyslog` installed in demo cluster
  - Added configuration files for `rsyslog` in order to save locally (default installation does it via `journald`, which is not used) in demo environment.
  - Added check for error status `118` (the one triggered by `ssh_command_wrapper.sh` when a command is not allowed) in `cscs_api_common.py`
- Also:
  - Added `CONTRIBUTORS.md` file
  - Minor fix in error message of `utilities.py` (`chown` to `chmod`)
  - Added Copyright in missing files.