### PR TITLE
Restapi 603 utilities file returns with status 200 in case of invalid path permission denied

### DIFF
--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -337,6 +337,10 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
         if stderr_errno == 0:
             if stderr_errda and not in_str(stderr_errda,"Could not chdir to home directory"):
                 result = {"error": 0, "msg": stderr_errda}
+            elif in_str(stdout_errda, "No such file"): # in case that error is 0 and the msg is on the stdout (like with some file)
+                result = {"error": 1, "msg": stdout_errda} 
+            elif in_str(stdout_errda, "no read permission"): # in case that error is 0 and the msg is on the stdout (like with some file)
+                result = {"error": 1, "msg": stdout_errda} 
             else:
                 result = {"error": 0, "msg": outlines}
         elif stderr_errno > 0:
@@ -347,6 +351,7 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
             result = {"error": -2, "msg": "Receive ready timeout exceeded"}
         elif stderr_errno == -1:
             result = {"error": -1, "msg": "No exit status was provided by the server"}
+        
 
     # first if paramiko exception raise
     except paramiko.ssh_exception.NoValidConnectionsError as e:
@@ -386,7 +391,7 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
         os.remove(priv_key)
         os.rmdir(temp_dir)
 
-    logging.info(f"Result returned: {result['msg']}")
+    logging.info(f"Result: status_code {result['error']} -> {result['msg']}")
     return result
 
 
@@ -699,10 +704,6 @@ def check_command_error(error_str, error_code, service_msg):
         header={"X-Invalid-Path":"path is an invalid path"}
         return {"description": service_msg, "status_code": 400, "header": header}
 
-    if in_str(error_str,"cannot open"):
-        header = {"X-Permission-Denied": "User does not have permissions to access path"}
-        return {"description":service_msg, "status_code": 400, "header": header}
-
     if in_str(error_str,"No such file"):
         if in_str(error_str,"cannot stat"):
             header={"X-Not-Found":"sourcePath not found"}
@@ -719,6 +720,10 @@ def check_command_error(error_str, error_code, service_msg):
 
         header={"X-Invalid-Path":"path is an invalid path"}
         return {"description": service_msg, "status_code": 400, "header": header}
+
+    if in_str(error_str,"cannot open"):
+        header = {"X-Permission-Denied": "User does not have permissions to access path"}
+        return {"description":service_msg, "status_code": 400, "header": header}
 
     if in_str(error_str,"Permission denied"):
         header = {"X-Permission-Denied": "User does not have permissions to access path"}

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -341,6 +341,8 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
                 result = {"error": 1, "msg": stdout_errda} 
             elif in_str(stdout_errda, "no read permission"): # in case that error is 0 and the msg is on the stdout (like with some file)
                 result = {"error": 1, "msg": stdout_errda} 
+            elif in_str(stdout_errda, "cannot open"): # in case that error is 0 and the msg is on the stdout (like with some file)
+                result = {"error": 1, "msg": stdout_errda} 
             else:
                 result = {"error": 0, "msg": outlines}
         elif stderr_errno > 0:

--- a/src/tests/automated_tests/unit/test_unit_utilities.py
+++ b/src/tests/automated_tests/unit/test_unit_utilities.py
@@ -26,8 +26,15 @@ SSL_CRT = os.environ.get("F7T_SSL_CRT", "")
 SSL_PATH = "../../../deploy/test-build"
 
 
-# test data for rename, chmod,chown, file, download,upload
+# test data for rename, chmod,chown, download,upload
 DATA = [ (SERVER_UTILITIES, 200) , ("someservernotavailable", 400)]  
+
+# test data for file
+DATA_FILE = [ (SERVER_UTILITIES, 200, ".bashrc") , 
+         ("someservernotavailable", 400, ".bashrc"), 
+		 (SERVER_UTILITIES, 400, "nofile") , 
+		 (SERVER_UTILITIES, 400, "/var/log/messages") , 
+		 ]  
 
 # test data for #mkdir, symlink
 DATA_201 = [ (SERVER_UTILITIES, 201) , ("someservernotavailable", 400)]  
@@ -102,13 +109,25 @@ def test_upload(machine, expected_response_code, headers):
 
 
 # Test exec file command on remote system
+@pytest.mark.parametrize("machine, expected_response_code,file_name", DATA_FILE)
+def test_file_type(machine, expected_response_code, file_name, headers):
+	url = "{}/file".format(UTILITIES_URL)
+	params = {"targetPath": file_name}
+	headers.update({"X-Machine-Name": machine})
+	resp = requests.get(url, headers=headers, params=params, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
+	print(resp.content)
+	print(resp.headers)
+	assert resp.status_code == expected_response_code  
+
+# Test exec file command on remote system
 @pytest.mark.parametrize("machine, expected_response_code", DATA)
-def test_file_type(machine, expected_response_code, headers):
+def test_file_type_error(machine, expected_response_code, headers):
 	url = "{}/file".format(UTILITIES_URL)
 	params = {"targetPath": ".bashrc"}
 	headers.update({"X-Machine-Name": machine})
 	resp = requests.get(url, headers=headers, params=params, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
 	print(resp.content)
+	print(resp.headers)
 	assert resp.status_code == expected_response_code  
 	 
 


### PR DESCRIPTION
- Modified function `exec_remote_command` in `src/common/cscs_api_common.py` to check error whether `errno` and `stderr` are null, and error message is shown in `stdout`. This happens when `file` command is executed in centos 7 systems (version `file-5.11`; for newer versions, passing the parameter `-E` would trigger error code > 0)
- Added more tests for `/utilities/file` endpoint