### PR TITLE
fixed scancel error message on task output

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -823,7 +823,10 @@ def cancel_job_task(auth_header,system_name, system_addr,action,task_id):
 
     # if "error" word appears:
     if in_str(data,"error"):
-        update_task(task_id, auth_header, async_task.ERROR, data)
+        # error message: "scancel: error: Kill job error on job id 5: Invalid job id specified"
+        # desired output: "Kill job error on job id 5: Invalid job id specified"
+        err_msg = data[(data.index("error")+7):]
+        update_task(task_id, auth_header, async_task.ERROR, err_msg)
         return
 
     # otherwise


### PR DESCRIPTION
Output for error on `DELETE /compute/jobs/<jobid>` has been formatted to be shown nicely by task microservice.

Old message: `scancel: error: Kill job error on job id 5: Invalid job id specified`
New message: `Kill job error on job id 5: Invalid job id specified`

Old message: `scancel: Terminating job 8scancel: error: Kill job error on job id 8: Job/step already completing or completed`
New message: `Kill job error on job id 8: Job/step already completing or completed`