### PR TITLE
compute.py: removed forgotten TASK_URL in data field of submit job task

### DIFF
--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -434,7 +434,7 @@ def submit_job_upload():
                              args=(auth_header, system_name, system_addr, job_file, job_dir, task_id))
 
         aTask.start()
-        retval = update_task(task_id, auth_header,async_task.QUEUED, TASKS_URL)
+        retval = update_task(task_id, auth_header,async_task.QUEUED)
 
         task_url = f"{KONG_URL}/tasks/{task_id}"
         data = jsonify(success="Task created", task_id=task_id, task_url=task_url)


### PR DESCRIPTION
When a job was submitted using `submit_job_upload` function, `msg` parameter of `update_task` was passed with `TASK_URL` value. Therefore, `data` field of `task` instead of having `{}` as expected, had `TASK_URL` value.