### PR TITLE
Restapi 601 testing bonus

### DIFF
--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -1,5 +1,10 @@
 #!groovy
-
+//
+//  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+//
+//  Please, refer to the LICENSE file in the root directory.
+//  SPDX-License-Identifier: BSD-3-Clause
+//
 node {
     def gitHubUser = 'eth-cscs'
     def gitHubRepo = 'firecrest'

--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -34,6 +34,8 @@ pipeline {
         stage('Refresh') {
             when {
                 anyOf {
+                    // For now, we use these branches to build everythig from scratch
+                    // See refresh.sh
                     branch 'master';
                     branch 'dev'
                 }
@@ -71,6 +73,7 @@ pipeline {
 
         success {
             script {
+                // Notify Github on success
                 withCredentials([string(credentialsId: 'firecrestci_access_token', variable: 'accessToken')]) {
                     sh 'curl -H "Authorization: token ' + "${accessToken}"  + '" "https://api.github.com/repos/eth-cscs/firecrest/statuses/' + "${env.GIT_COMMIT}" + '" \\' +
                     '-H "Content-Type: application/json" \\' +
@@ -82,6 +85,7 @@ pipeline {
 
         unsuccessful{
             script {
+                // Notify Github on failure
                 withCredentials([string(credentialsId: 'firecrestci_access_token', variable: 'accessToken')]) {
                     sh 'curl -H "Authorization: token ' + "${accessToken}"  + '" "https://api.github.com/repos/eth-cscs/firecrest/statuses/' + "${env.GIT_COMMIT}" + '" \\' +
                     '-H "Content-Type: application/json" \\' +

--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                 // Save log files
                 try {
                     sh "mkdir -p /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
-                    sh "cp -r deploy/test-build/logs/firecrest/* /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}/. || echo 'no logs folder found"
+                    sh "cp -r deploy/test-build/logs/firecrest/* /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}/."
                 } catch (errCpLogs) {
                     echo 'Error while saving log files: ' + errCpLogs.toString()
                 }

--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
                 echo "NODE_LABELS : ${env.NODE_LABELS}"
                 echo "WORKSPACE : ${env.WORKSPACE}"
                 echo "JENKINS_HOME : ${env.JENKINS_HOME}"
+                echo "GIT COMMIT: ${env.GIT_COMMIT}"
                 sh "docker --version"
                 sh "docker-compose --version"
                 sh "bash --version"
@@ -58,15 +59,40 @@ pipeline {
     post {
         always {
             script {
-                // Save log files
+                // Save the log files
                 try {
                     sh "mkdir -p /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
                     sh "cp -r deploy/test-build/logs/firecrest/* /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}/."
                 } catch (errCpLogs) {
                     echo 'Error while saving log files: ' + errCpLogs.toString()
                 }
+            }
+        }
 
-                // Cleanup
+        success {
+            script {
+                withCredentials([string(credentialsId: 'firecrestci_access_token', variable: 'accessToken')]) {
+                    sh 'curl -H "Authorization: token ' + "${accessToken}"  + '" "https://api.github.com/repos/eth-cscs/firecrest/statuses/' + "${env.GIT_COMMIT}" + '" \\' +
+                    '-H "Content-Type: application/json" \\' +
+                    '-X POST \\' +
+                    '-d "{\\"state\\": \\"success\\",\\"context\\": \\"continuous-integration/jenkins\\", \\"description\\": \\"Jenkins\\", \\"target_url\\": \\"' + "${env.BUILD_URL}" + '/console\\"}"'
+                }
+            }
+        }
+
+        unsuccessful{
+            script {
+                withCredentials([string(credentialsId: 'firecrestci_access_token', variable: 'accessToken')]) {
+                    sh 'curl -H "Authorization: token ' + "${accessToken}"  + '" "https://api.github.com/repos/eth-cscs/firecrest/statuses/' + "${env.GIT_COMMIT}" + '" \\' +
+                    '-H "Content-Type: application/json" \\' +
+                    '-X POST \\' +
+                    '-d "{\\"state\\": \\"failure\\",\\"context\\": \\"continuous-integration/jenkins\\", \\"description\\": \\"Jenkins\\", \\"target_url\\": \\"' + "${env.BUILD_URL}" + '/console\\"}"'
+                }
+            }
+        }
+
+        cleanup {
+            script {
                 try {
                     sh "ci/dev/clean.sh"
                 } catch (errCpLogs) {

--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -31,63 +31,26 @@ node {
             echo "JENKINS_HOME : ${env.JENKINS_HOME}"
         }
 
-        stage('Build') {
-            echo 'Build Stage Starting'
+        stage('Refresh') {
+            when {
+                expression { return branch 'master' || branch 'dev' }
+            }
+            steps {
+                sh "${env.WORKSPACE}/ci/dev/refresh.sh"
+            }
+        }
 
-            // delete log folder if exists
+        stage('Setup') {
             try {
-                sh "rm -rf ${env.WORKSPACE}/deploy/test-build/logs/firecrest"
+                sh "${env.WORKSPACE}/ci/dev/setup.sh"
             } catch (ex0) {
-                echo 'Error: Can not delete logs/firecrest folder'
+                echo 'Error: Failed to run setup.sh'
             }
-
-            // create folder for logs
-            try {
-                sh "mkdir -p ${env.WORKSPACE}/deploy/test-build/logs/firecrest"
-            } catch (ex1) {
-                echo 'Error creating logs/firecrest folder'
-            }
-
-            // give write permissions to users in jenkins group (root user must belong to it)
-            try {
-                sh "chmod 775 ${env.WORKSPACE}/deploy/test-build/logs/firecrest"
-            } catch (ex2) {
-                echo 'Error: Can not change permissions of logs/firecrest folder'
-            }
-
-            dir('deploy/test-build/environment/keys') {
-                sh 'chmod 400 ca-key user-key'
-            }
-
-            withEnv(["PATH=$PATH:/usr/local/bin"]) {
-                dir('deploy/test-build') {
-                    sh 'docker-compose up --build -d'
-                }
-            }
-
-            sh '''#!/bin/sh
-            sleep 60
-            echo "Waiting for containers to get ready..."
-            '''
-
-            echo 'Build Stage Finsihed'
         }
 
         stage('Tests') {
-            dir('src/tests/automated_tests') {
-                sh 'pip3 install --user -r requirements.txt'
-
-                withEnv(["PATH=$PATH:~/.local/bin"]) {
-                    echo 'Unit Tests Starting'
-                    sh 'pytest -c test-build.ini unit'
-                    echo 'Unit Tests Finished'
-
-                    echo 'Integration Tests Starting'
-                    sh 'pytest -c test-build.ini integration'
-                    echo 'Integrations Tests Finished'
-                }
-
-                echo 'Tests Finished'
+            withEnv(["PATH=$PATH:~/.local/bin"]) {
+                sh "${env.WORKSPACE}/ci/dev/test.sh"
             }
         }
     }
@@ -105,17 +68,9 @@ node {
             echo 'Error while saving log files: ' + errCpLogs.toString()
         }
 
-        sh '''#!/bin/sh
-        sleep 30
-        echo "Waiting 30 seconds before containers removal..."
-        '''
-
         // Remove containers
-        withEnv(["PATH=$PATH:/usr/local/bin"]) {
-            dir('deploy/test-build') {
-                // destroy containers and volumes
-                sh 'docker-compose down -v'
-            }
+        withEnv(["PATH=$PATH:~/.local/bin"]) {
+            sh "${env.WORKSPACE}/ci/dev/clean.sh"
         }
 
         notifyBuildStatusToGitHub(currentBuild.result, gitHubUser, gitHubRepo, longCommit)

--- a/ci/dev/Jenkinsfile
+++ b/ci/dev/Jenkinsfile
@@ -5,96 +5,74 @@
 //  Please, refer to the LICENSE file in the root directory.
 //  SPDX-License-Identifier: BSD-3-Clause
 //
-node {
-    def gitHubUser = 'eth-cscs'
-    def gitHubRepo = 'firecrest'
-
-    // $after contains the commit id obtained trough github webhook
-    def longCommit = "$after"
-
-    try {
-        stage('Checkout source code') {
-            echo 'Checking out source code'
-
-            git branch: 'master',
-            url: 'https://github.com/' + gitHubUser + '/' + gitHubRepo + '.git'
-
-            // checkout the specified commit
-            sh('git checkout ' + longCommit)
-        }
-
-        stage('Print Env After source checkout') {
-            echo "Branch Name: ${env.BRANCH_NAME}"
-            echo "BUILD_NUMBER : ${env.BUILD_NUMBER}"
-            echo "BUILD_ID : ${env.BUILD_ID}"
-            echo "JOB_NAME: ${env.JOB_NAME}"
-            echo "BUILD_TAG : ${env.BUILD_TAG}"
-            echo "EXECUTOR_NUMBER : ${env.EXECUTOR_NUMBER}"
-            echo "NODE_NAME: ${env.NODE_NAME}"
-            echo "NODE_LABELS : ${env.NODE_LABELS}"
-            echo "WORKSPACE : ${env.WORKSPACE}"
-            echo "JENKINS_HOME : ${env.JENKINS_HOME}"
+pipeline {
+    agent any
+    stages {
+        stage('Info') {
+            steps {
+                echo "Branch Name: ${env.BRANCH_NAME}"
+                echo "BUILD_NUMBER : ${env.BUILD_NUMBER}"
+                echo "BUILD_ID : ${env.BUILD_ID}"
+                echo "JOB_NAME: ${env.JOB_NAME}"
+                echo "BUILD_TAG : ${env.BUILD_TAG}"
+                echo "EXECUTOR_NUMBER : ${env.EXECUTOR_NUMBER}"
+                echo "NODE_NAME: ${env.NODE_NAME}"
+                echo "NODE_LABELS : ${env.NODE_LABELS}"
+                echo "WORKSPACE : ${env.WORKSPACE}"
+                echo "JENKINS_HOME : ${env.JENKINS_HOME}"
+                sh "docker --version"
+                sh "docker-compose --version"
+                sh "bash --version"
+                sh "git --version"
+                sh "pwd"
+                sh "ls -la"
+                sh "git status"
+            }
         }
 
         stage('Refresh') {
             when {
-                expression { return branch 'master' || branch 'dev' }
+                anyOf {
+                    branch 'master';
+                    branch 'dev'
+                }
             }
             steps {
-                sh "${env.WORKSPACE}/ci/dev/refresh.sh"
+                sh "ci/dev/refresh.sh"
             }
         }
 
         stage('Setup') {
-            try {
-                sh "${env.WORKSPACE}/ci/dev/setup.sh"
-            } catch (ex0) {
-                echo 'Error: Failed to run setup.sh'
+            steps {
+                sh "ci/dev/setup.sh"
             }
         }
 
         stage('Tests') {
-            withEnv(["PATH=$PATH:~/.local/bin"]) {
-                sh "${env.WORKSPACE}/ci/dev/test.sh"
+            steps {
+                sh "ci/dev/test.sh"
             }
         }
     }
-    catch (e) {
-        // If there was an exception, the build failed
-        currentBuild.result = 'FAILED'
-        throw e
-    }
-    finally {
-        // Save Log files
-        try {
-            sh "mkdir -p /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
-            sh "cp -r ${env.WORKSPACE}/deploy/test-build/logs/firecrest/* /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}/."
-        } catch (errCpLogs) {
-            echo 'Error while saving log files: ' + errCpLogs.toString()
+
+    post {
+        always {
+            script {
+                // Save log files
+                try {
+                    sh "mkdir -p /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}"
+                    sh "cp -r deploy/test-build/logs/firecrest/* /var/log/jenkins/jobs/${env.JOB_NAME}/builds/${env.BUILD_NUMBER}/. || echo 'no logs folder found"
+                } catch (errCpLogs) {
+                    echo 'Error while saving log files: ' + errCpLogs.toString()
+                }
+
+                // Cleanup
+                try {
+                    sh "ci/dev/clean.sh"
+                } catch (errCpLogs) {
+                    echo 'Error while trying to clean: ' + errCpLogs.toString()
+                }
+            }
         }
-
-        // Remove containers
-        withEnv(["PATH=$PATH:~/.local/bin"]) {
-            sh "${env.WORKSPACE}/ci/dev/clean.sh"
-        }
-
-        notifyBuildStatusToGitHub(currentBuild.result, gitHubUser, gitHubRepo, longCommit)
-    }
-}
-
-def notifyBuildStatusToGitHub(String buildStatus, String gitHubUser, String gitHubRepo, String longCommit) {
-    buildStatus = buildStatus ?: 'SUCCESS'
-    def status = ''
-    if (buildStatus == 'SUCCESS') {
-        status = 'success'
-    } else {
-        status = 'failure'
-    }
-
-    withCredentials([string(credentialsId: 'firecrestci_access_token', variable: 'accessToken')]) {
-        sh 'curl -H "Authorization: token ' + "${accessToken}"  + '" "https://api.github.com/repos/' + gitHubUser + '/' + gitHubRepo + '/statuses/' + longCommit + '" \\' +
-        '-H "Content-Type: application/json" \\' +
-        '-X POST \\' +
-        '-d "{\\"state\\": \\"' + status + '\\",\\"context\\": \\"continuous-integration/jenkins\\", \\"description\\": \\"Jenkins\\", \\"target_url\\": \\"' + "${env.BUILD_URL}" + '/console\\"}"'
     }
 }

--- a/ci/dev/README.md
+++ b/ci/dev/README.md
@@ -4,7 +4,7 @@
 
 You can run the tests on any linux machine with...
 
-- [bash](https://www.gnu.org/software/bash/) >= `4` (with sudo)
+- [bash](https://www.gnu.org/software/bash/) >= `4`
 - [docker](https://docs.docker.com/engine/install/) >= `20.10.1`
 - [docker-compose](https://docs.docker.com/compose/install/) >= `1.26.2`
 

--- a/ci/dev/README.md
+++ b/ci/dev/README.md
@@ -5,8 +5,8 @@
 You can run the tests on any linux machine with...
 
 - [bash](https://www.gnu.org/software/bash/) >= `4`
-- [docker](https://docs.docker.com/engine/install/) >= `20.10.1`
-- [docker-compose](https://docs.docker.com/compose/install/) >= `1.26.2`
+- [docker](https://docs.docker.com/engine/install/) >= `20.10`
+- [docker-compose](https://docs.docker.com/compose/install/) >= `1.28`
 
 ## Usage
 

--- a/ci/dev/README.md
+++ b/ci/dev/README.md
@@ -1,0 +1,41 @@
+# FirecREST Testing
+
+## Requirements
+
+You can run the tests on any linux machine with...
+
+- [bash](https://www.gnu.org/software/bash/) >= `4` (with sudo)
+- [docker](https://docs.docker.com/engine/install/) >= `20.10.1`
+- [docker-compose](https://docs.docker.com/compose/install/) >= `1.26.2`
+
+## Usage
+
+Clone this repo and cd into it...
+
+```
+git clone https://github.com/eth-cscs/firecrest
+cd firecrest
+```
+
+To run all tests for the first time simply run...
+
+```
+ci/dev/run.sh
+```
+
+Have a look at that script. It will setup and build everything from the scratch and run ALL the dev tests.
+
+If you have already setup everything and just want to re-run some tests without recreating everything
+from the scratch, you can call the scripts that `ci/dev/test.sh` is calling.
+
+```
+ci/dev/test.sh
+```
+
+## Debugging
+
+If you want to re-test something specific, you can customize the docker calls of the end of `ci/dev/tests.sh`
+to make an ad-hoc pytest call.
+
+If the stdout information is not enough, remember to check either the logs in the logs folder created in `ci/dev/setup.sh`
+or the container logs with [docker logs](https://docs.docker.com/engine/reference/commandline/logs/).

--- a/ci/dev/README.md
+++ b/ci/dev/README.md
@@ -23,10 +23,10 @@ To run all tests for the first time simply run...
 ci/dev/run.sh
 ```
 
-Have a look at that script. It will setup and build everything from the scratch and run ALL the dev tests.
+Have a look at that script. It will setup and build everything from scratch and run ALL the dev tests.
 
 If you have already setup everything and just want to re-run some tests without recreating everything
-from the scratch, you can call the scripts that `ci/dev/test.sh` is calling.
+from scratch, you can call the scripts that `ci/dev/test.sh` is calling.
 
 ```
 ci/dev/test.sh
@@ -34,7 +34,7 @@ ci/dev/test.sh
 
 ## Debugging
 
-If you want to re-test something specific, you can customize the docker calls of the end of `ci/dev/tests.sh`
+If you want to re-test something specific, you can customize the docker calls of the end of `ci/dev/test.sh`
 to make an ad-hoc pytest call.
 
 If the stdout information is not enough, remember to check either the logs in the logs folder created in `ci/dev/setup.sh`

--- a/ci/dev/clean.sh
+++ b/ci/dev/clean.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 echo "starting" $0
 WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
 
-sudo rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest/* || true
-sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
+rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest/* || true
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
 
 echo "finished" $0

--- a/ci/dev/clean.sh
+++ b/ci/dev/clean.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "starting" $0
+WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
+
+sudo rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest/* || true
+sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
+
+echo "finished" $0

--- a/ci/dev/clean.sh
+++ b/ci/dev/clean.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 set -euo pipefail
 
 echo "starting" $0

--- a/ci/dev/refresh.sh
+++ b/ci/dev/refresh.sh
@@ -11,13 +11,13 @@ echo "starting" $0
 WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
 
 echo "removing potential leftovers"
-sudo rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest || true
-sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v --rmi all --remove-orphans || true
-sudo docker rmi f7t-base f7t-tester || echo "no base image to delete, no problem!"
+rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest || true
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v --rmi all --remove-orphans || true
+docker rmi f7t-base f7t-tester || echo "no base image to delete, no problem!"
 
 echo "building images from scratch"
-sudo docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
-sudo docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
-sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build #--no-cache
+docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
+docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build #--no-cache
 
 echo "finished" $0

--- a/ci/dev/refresh.sh
+++ b/ci/dev/refresh.sh
@@ -15,9 +15,11 @@ rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest || true
 docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v --rmi all --remove-orphans || true
 docker rmi f7t-base f7t-tester || echo "no base image to delete, no problem!"
 
-echo "building images from scratch"
-docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
-docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
+echo "building images from scratch (no caches)"
+# Building from scratch is slower, but prevents cache-invalidation issues, typical of cached CI machines.
+# You may want to do this only once a while, not for every feature branch.
+docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --no-cache --pull ${WORKSPACE}
+docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --no-cache --pull ${WORKSPACE}
 docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build --no-cache
 
 echo "finished" $0

--- a/ci/dev/refresh.sh
+++ b/ci/dev/refresh.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 set -euo pipefail
 
 echo "starting" $0

--- a/ci/dev/refresh.sh
+++ b/ci/dev/refresh.sh
@@ -18,6 +18,6 @@ docker rmi f7t-base f7t-tester || echo "no base image to delete, no problem!"
 echo "building images from scratch"
 docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
 docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
-docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build #--no-cache
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build --no-cache
 
 echo "finished" $0

--- a/ci/dev/refresh.sh
+++ b/ci/dev/refresh.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "starting" $0
+WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
+
+echo "removing potential leftovers"
+sudo rm -rfv ${WORKSPACE}/deploy/test-build/logs/firecrest || true
+sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v --rmi all --remove-orphans || true
+sudo docker rmi f7t-base f7t-tester || echo "no base image to delete, no problem!"
+
+echo "building images from scratch"
+sudo docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
+sudo docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
+sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build #--no-cache
+
+echo "finished" $0

--- a/ci/dev/run.sh
+++ b/ci/dev/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "starting" $0
+WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+
+$WORKSPACE/refresh.sh
+$WORKSPACE/setup.sh
+$WORKSPACE/test.sh
+
+echo "finished" $0

--- a/ci/dev/run.sh
+++ b/ci/dev/run.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 set -euo pipefail
 
 echo "starting" $0

--- a/ci/dev/setup.sh
+++ b/ci/dev/setup.sh
@@ -18,4 +18,9 @@ echo "adjusting keys..."
 chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/ca-key
 chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/user-key
 
+echo "building images with cache"
+docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
+docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build
+
 echo "finished" $0

--- a/ci/dev/setup.sh
+++ b/ci/dev/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "starting" $0
+WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
+
+echo "prepare fresh logs folder..."
+mkdir -pv ${WORKSPACE}/deploy/test-build/logs/firecrest
+chmod 775 ${WORKSPACE}/deploy/test-build/logs/firecrest
+
+echo "adjusting keys..."
+chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/ca-key
+chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/user-key
+
+echo "finished" $0

--- a/ci/dev/setup.sh
+++ b/ci/dev/setup.sh
@@ -18,9 +18,9 @@ echo "adjusting keys..."
 chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/ca-key
 chmod 400 ${WORKSPACE}/deploy/test-build/environment/keys/user-key
 
-echo "building images with cache"
-docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base --pull ${WORKSPACE}
-docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester --pull ${WORKSPACE}
+echo "building images (with caches)"
+docker build -f ${WORKSPACE}/deploy/docker/base/Dockerfile -t f7t-base ${WORKSPACE}
+docker build -f ${WORKSPACE}/deploy/docker/tester/Dockerfile -t f7t-tester ${WORKSPACE}
 docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml build
 
 echo "finished" $0

--- a/ci/dev/setup.sh
+++ b/ci/dev/setup.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 set -euo pipefail
 
 echo "starting" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -15,6 +15,7 @@ ${WORKSPACE}/ci/dev/clean.sh
 echo "starting containers..."
 docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml up --build -d
 
+# TODO: Complete the missing endpoints (readinessProbe like) to allow this kind of wait
 # echo "waiting for Firecrest stack to be ready..."
 # attempts=0
 # while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9000)" == "000" ]]; do

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -15,18 +15,20 @@ ${WORKSPACE}/ci/dev/clean.sh
 echo "starting containers..."
 docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml up --build -d
 
-echo "waiting for Firecrest stack to be ready..."
-attempts=0
-while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9000)" == "000" ]]; do
-    let "attempts+=1"
-    echo "API NOT ready, next attempt in 60 seconds"
-    sleep 60
-done
-if [[ "$attempts" -ge 9 ]]; then
-    echo "TIMEOUT waiting API. Shutting down cluster..."
-    docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
-    exit 1
-fi
+# echo "waiting for Firecrest stack to be ready..."
+# attempts=0
+# while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9000)" == "000" ]]; do
+#     let "attempts+=1"
+#     echo "API NOT ready, next attempt in 60 seconds"
+#     sleep 60
+# done
+# if [[ "$attempts" -ge 9 ]]; then
+#     echo "TIMEOUT waiting API. Shutting down cluster..."
+#     docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
+#     exit 1
+# fi
+echo "sleeping..."
+sleep 120
 
 echo "running unit_tests..."
 docker run --rm -u $(id -u):$(id -g) -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -23,11 +23,11 @@ if [[ "$attempts" -ge 9 ]]; then
 fi
 
 echo "running unit_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend python:3.8.5-slim bash \
-    -c 'pip install -r /firecrest/src/tests/automated_tests/requirements.txt; cd /firecrest/src/tests/automated_tests && pytest -c test-build.ini unit'
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend f7t-tester bash \
+    -c 'pytest -c test-build.ini unit'
 
 echo "running integration_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend python:3.8.5-slim bash \
-    -c 'pip install -r /firecrest/src/tests/automated_tests/requirements.txt; cd /firecrest/src/tests/automated_tests && pytest -c test-build.ini integration'
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend f7t-tester bash \
+    -c 'pytest -c test-build.ini integration'
 
 echo "finished" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -29,11 +29,11 @@ if [[ "$attempts" -ge 9 ]]; then
 fi
 
 echo "running unit_tests..."
-docker run --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run --rm -u $(id -u):$(id -g) -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini unit'
 
 echo "running integration_tests..."
-docker run --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run --rm -u $(id -u):$(id -g) -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini integration'
 
 echo "finished" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "starting" $0
+WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
+
+${WORKSPACE}/ci/dev/clean.sh
+
+echo "starting containers..."
+sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml up --build -d
+
+echo "waiting for Firecrest stack to be ready..."
+attempts=0
+while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9000)" == "000" ]]; do
+    let "attempts+=1"
+    echo "API NOT ready, next attempt in 5 seconds"
+    sleep 5
+done
+if [[ "$attempts" -ge 9 ]]; then
+    echo "TIMEOUT waiting API. Shutting down cluster..."
+    sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
+    exit 1
+fi
+
+echo "running unit_tests..."
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend python:3.8.5-slim bash \
+    -c 'pip install -r /firecrest/src/tests/automated_tests/requirements.txt; cd /firecrest/src/tests/automated_tests && pytest -c test-build.ini unit'
+
+echo "running integration_tests..."
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend python:3.8.5-slim bash \
+    -c 'pip install -r /firecrest/src/tests/automated_tests/requirements.txt; cd /firecrest/src/tests/automated_tests && pytest -c test-build.ini integration'
+
+echo "finished" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -13,7 +13,7 @@ WORKSPACE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/../../
 ${WORKSPACE}/ci/dev/clean.sh
 
 echo "starting containers..."
-sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml up --build -d
+docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml up --build -d
 
 echo "waiting for Firecrest stack to be ready..."
 attempts=0
@@ -24,16 +24,16 @@ while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localh
 done
 if [[ "$attempts" -ge 9 ]]; then
     echo "TIMEOUT waiting API. Shutting down cluster..."
-    sudo docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
+    docker-compose -f ${WORKSPACE}/deploy/test-build/docker-compose.yml down -v
     exit 1
 fi
 
 echo "running unit_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini unit'
 
 echo "running integration_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini integration'
 
 echo "finished" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
 set -euo pipefail
 
 echo "starting" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -29,11 +29,11 @@ if [[ "$attempts" -ge 9 ]]; then
 fi
 
 echo "running unit_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend f7t-tester bash \
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini unit'
 
 echo "running integration_tests..."
-sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network test-build_frontend f7t-tester bash \
+sudo docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini integration'
 
 echo "finished" $0

--- a/ci/dev/test.sh
+++ b/ci/dev/test.sh
@@ -19,8 +19,8 @@ echo "waiting for Firecrest stack to be ready..."
 attempts=0
 while [[ "$attempts" -lt 9 && "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9000)" == "000" ]]; do
     let "attempts+=1"
-    echo "API NOT ready, next attempt in 5 seconds"
-    sleep 5
+    echo "API NOT ready, next attempt in 60 seconds"
+    sleep 60
 done
 if [[ "$attempts" -ge 9 ]]; then
     echo "TIMEOUT waiting API. Shutting down cluster..."
@@ -29,11 +29,11 @@ if [[ "$attempts" -ge 9 ]]; then
 fi
 
 echo "running unit_tests..."
-docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini unit'
 
 echo "running integration_tests..."
-docker run -ti --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
+docker run --rm -v ${WORKSPACE}:/firecrest --network f7t-frontend f7t-tester bash \
     -c 'pytest -c test-build.ini integration'
 
 echo "finished" $0

--- a/deploy/demo/common/common.env
+++ b/deploy/demo/common/common.env
@@ -54,7 +54,7 @@ F7T_RESERVATIONS_URL=https://192.168.220.8:5005
 # kong_url: used by microservices when return URL to clients
 F7T_KONG_URL=http://192.168.220.10:8000
 #-------
-# list of systems 
+# list of systems
 #public name for systems, where users except to submit jobs and get files (list with ';')
 F7T_SYSTEMS_PUBLIC='cluster;cluster'
 # filesystems mounted in each system
@@ -84,7 +84,7 @@ F7T_OBJECT_STORAGE='s3v4'
 # partition for internal transfer
 F7T_XFER_PARTITION=xfer
 # set if account is needed for SLURM job submission
-F7T_USE_SLURM_ACCOUNT=True 
+F7T_USE_SLURM_ACCOUNT=True
 # machine for external transfers
 F7T_EXT_TRANSFER_MACHINE_PUBLIC='cluster'
 F7T_EXT_TRANSFER_MACHINE_INTERNAL='192.168.220.12:22'
@@ -109,7 +109,6 @@ F7T_KONG_TASKS_URL=http://192.168.220.6:5003
 F7T_KONG_UTILITIES_URL=http://192.168.220.7:5004
 F7T_KONG_RESERVATIONS_URL=http://192.168.220.8:5005
 #------
-#F7T_DEBUG_MODE=True
 # OPA Vars
 F7T_OPA_USE=True
 F7T_OPA_URL=https://192.168.220.40:8181

--- a/deploy/docker/base/Dockerfile
+++ b/deploy/docker/base/Dockerfile
@@ -1,0 +1,16 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+from centos:7 as f7t-base
+
+# install epel repo for python-pip package
+RUN yum install -y epel-release
+RUN yum -y update
+RUN yum install -y python3-pip
+
+RUN pip3 install --upgrade pip
+
+ADD deploy/docker/base/requirements.txt base/requirements.txt

--- a/deploy/docker/base/requirements.txt
+++ b/deploy/docker/base/requirements.txt
@@ -1,0 +1,4 @@
+cryptography==2.8
+Flask==1.1.2
+PyJWT==1.7.1
+requests==2.22.0

--- a/deploy/docker/certificator/Dockerfile
+++ b/deploy/docker/certificator/Dockerfile
@@ -4,28 +4,14 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7
-
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-RUN yum install -y python3-pip
-
-# upgrade
-RUN pip3 install --upgrade pip
+from f7t-base
 
 RUN yum install -y openssh
 
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/certificator/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 
 ADD src/certificator/certificator.py certificator.py
-# ADD src/common/cscs_api_common.py cscs_api_common.py
 
 ENTRYPOINT ["python3"]
 CMD ["certificator.py"]
-

--- a/deploy/docker/certificator/Dockerfile
+++ b/deploy/docker/certificator/Dockerfile
@@ -19,7 +19,9 @@ RUN pip3 install --upgrade pip
 
 RUN yum install -y openssh
 
-RUN pip3 install Flask cryptography pyjwt requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/certificator/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/certificator/certificator.py certificator.py
 # ADD src/common/cscs_api_common.py cscs_api_common.py

--- a/deploy/docker/certificator/requirements.txt
+++ b/deploy/docker/certificator/requirements.txt
@@ -1,0 +1,1 @@
+-r ../base/requirements.txt

--- a/deploy/docker/compute/Dockerfile
+++ b/deploy/docker/compute/Dockerfile
@@ -4,15 +4,8 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7
+from f7t-base
 
-RUN yum install -y epel-release
-RUN yum -y update
-RUN yum install -y python3-pip
-
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/compute/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 
@@ -23,4 +16,3 @@ ADD src/common/job_time.py job_time.py
 
 ENTRYPOINT ["python3"]
 CMD ["compute.py"]
-

--- a/deploy/docker/compute/Dockerfile
+++ b/deploy/docker/compute/Dockerfile
@@ -12,7 +12,9 @@ RUN yum install -y python3-pip
 
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask paramiko cryptography pyjwt requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/compute/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/compute/compute.py compute.py
 ADD src/common/async_task.py async_task.py

--- a/deploy/docker/compute/requirements.txt
+++ b/deploy/docker/compute/requirements.txt
@@ -1,0 +1,2 @@
+-r ../base/requirements.txt
+paramiko==2.6.0

--- a/deploy/docker/reservations/Dockerfile
+++ b/deploy/docker/reservations/Dockerfile
@@ -1,17 +1,5 @@
-from centos:7
+from f7t-base
 
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-RUN yum install -y python3-pip
-
-# upgrade
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/reservations/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 

--- a/deploy/docker/reservations/Dockerfile
+++ b/deploy/docker/reservations/Dockerfile
@@ -11,7 +11,9 @@ RUN yum install -y python3-pip
 # upgrade
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask paramiko cryptography pyjwt requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/reservations/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/reservations/reservations.py reservations.py
 ADD src/common/cscs_api_common.py cscs_api_common.py

--- a/deploy/docker/reservations/requirements.txt
+++ b/deploy/docker/reservations/requirements.txt
@@ -1,0 +1,2 @@
+-r ../base/requirements.txt
+paramiko==2.6.0

--- a/deploy/docker/status/Dockerfile
+++ b/deploy/docker/status/Dockerfile
@@ -4,22 +4,8 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-FROM centos:7
+FROM f7t-base
 
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-# this install also python 3.6
-RUN yum install -y python3-pip
-# RUN yum remove -y cyrus-sasl-gssapi python-gssapi
-
-# upgrade
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/status/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 
@@ -28,4 +14,3 @@ ADD src/common/cscs_api_common.py cscs_api_common.py
 
 ENTRYPOINT ["python3"]
 CMD ["status.py"]
-

--- a/deploy/docker/status/Dockerfile
+++ b/deploy/docker/status/Dockerfile
@@ -19,7 +19,9 @@ RUN yum install -y python3-pip
 # upgrade
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask paramiko cryptography pyjwt requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/status/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/status/status.py status.py
 ADD src/common/cscs_api_common.py cscs_api_common.py

--- a/deploy/docker/status/requirements.txt
+++ b/deploy/docker/status/requirements.txt
@@ -1,0 +1,2 @@
+-r ../base/requirements.txt
+paramiko==2.6.0

--- a/deploy/docker/storage/Dockerfile
+++ b/deploy/docker/storage/Dockerfile
@@ -17,8 +17,9 @@ RUN yum install -y python3-pip
 # upgrade
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask paramiko lxml cryptography pyjwt keystoneauth1 python-keystoneclient
-
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/storage/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/storage/storage.py storage.py
 ADD src/storage/keystone.py keystone.py

--- a/deploy/docker/storage/Dockerfile
+++ b/deploy/docker/storage/Dockerfile
@@ -4,20 +4,8 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7
+from f7t-base
 
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-RUN yum install -y python3-pip
-
-# upgrade
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/storage/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 
@@ -31,7 +19,6 @@ ADD src/storage/swiftOS.py swiftOS.py
 ADD src/common/async_task.py async_task.py
 ADD src/common/job_time.py job_time.py
 ADD src/common/cscs_api_common.py cscs_api_common.py
-
 
 ENTRYPOINT ["python3"]
 CMD ["storage.py"]

--- a/deploy/docker/storage/requirements.txt
+++ b/deploy/docker/storage/requirements.txt
@@ -1,0 +1,5 @@
+-r ../base/requirements.txt
+keystoneauth1==4.3.0
+lxml==4.6.2
+paramiko==2.6.0
+python-keystoneclient==4.2.0

--- a/deploy/docker/tasks/Dockerfile
+++ b/deploy/docker/tasks/Dockerfile
@@ -4,20 +4,8 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7
+from f7t-base
 
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-RUN yum install -y python3-pip
-
-# upgrade
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/tasks/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 

--- a/deploy/docker/tasks/Dockerfile
+++ b/deploy/docker/tasks/Dockerfile
@@ -17,7 +17,9 @@ RUN yum install -y python3-pip
 # upgrade
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask cryptography pyjwt redis requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/tasks/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/tasks/tasks.py tasks.py
 ADD src/common/async_task.py async_task.py

--- a/deploy/docker/tasks/requirements.txt
+++ b/deploy/docker/tasks/requirements.txt
@@ -1,0 +1,2 @@
+-r ../base/requirements.txt
+redis==3.5.3

--- a/deploy/docker/tester/Dockerfile
+++ b/deploy/docker/tester/Dockerfile
@@ -13,6 +13,9 @@
 ##        See scripts in ci folder.
 from python:3.8.5-slim
 
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/tester/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt

--- a/deploy/docker/tester/Dockerfile
+++ b/deploy/docker/tester/Dockerfile
@@ -1,0 +1,22 @@
+##
+##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+##
+##  Please, refer to the LICENSE file in the root directory.
+##  SPDX-License-Identifier: BSD-3-Clause
+##
+##
+##  Usage:
+##        # (from repository root level)
+##        docker build -t f7t-tester -f deploy/docker/tester/Dockerfile .
+##        docker run -ti --rm -v $PWD:/firecrest f7t-tester
+##        # (now inside the container run pytest as you want)
+##        See scripts in ci folder.
+from python:3.8.5-slim
+
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/tester/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
+
+WORKDIR /firecrest/src/tests/automated_tests
+
+CMD [ "python3" ]

--- a/deploy/docker/tester/requirements.txt
+++ b/deploy/docker/tester/requirements.txt
@@ -2,4 +2,3 @@
 # dev-specific below:
 pytest==6.2.1
 pytest-dotenv==0.5.2
-pytest-dotenv==0.5.2

--- a/deploy/docker/tester/requirements.txt
+++ b/deploy/docker/tester/requirements.txt
@@ -1,6 +1,4 @@
-# see with deploy/docker/base/requirements
-PyJWT==1.7.1
-requests==2.22.0
+-r ../base/requirements.txt
 # dev-specific below:
 pytest==6.2.1
 pytest-dotenv==0.5.2

--- a/deploy/docker/utilities/Dockerfile
+++ b/deploy/docker/utilities/Dockerfile
@@ -17,7 +17,9 @@ RUN yum install -y python3-pip
 # upgrade
 RUN pip3 install --upgrade pip
 
-RUN pip3 install Flask paramiko cryptography pyjwt requests
+ADD deploy/docker/base/requirements.txt base/requirements.txt
+ADD deploy/docker/utilities/requirements.txt deps/requirements.txt
+RUN pip3 install -r deps/requirements.txt
 
 ADD src/utilities/utilities.py utilities.py
 ADD src/common/cscs_api_common.py cscs_api_common.py

--- a/deploy/docker/utilities/Dockerfile
+++ b/deploy/docker/utilities/Dockerfile
@@ -4,20 +4,8 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7
+from f7t-base
 
-# install epel repo for python-pip package
-RUN yum install -y epel-release
-# update yum
-RUN yum -y update
-
-# install python-pip from repo
-RUN yum install -y python3-pip
-
-# upgrade
-RUN pip3 install --upgrade pip
-
-ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/utilities/requirements.txt deps/requirements.txt
 RUN pip3 install -r deps/requirements.txt
 
@@ -26,4 +14,3 @@ ADD src/common/cscs_api_common.py cscs_api_common.py
 
 ENTRYPOINT ["python3"]
 CMD ["utilities.py"]
-

--- a/deploy/docker/utilities/requirements.txt
+++ b/deploy/docker/utilities/requirements.txt
@@ -1,0 +1,2 @@
+-r ../base/requirements.txt
+paramiko==2.6.0

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       dockerfile: deploy/docker/certificator/Dockerfile
     env_file:
       - ./environment/common.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - "./environment/keys/ca-key:/ca-key:ro"
       - "./environment/keys/user-key.pub:/user-key.pub:ro"
@@ -26,7 +28,9 @@ services:
       dockerfile: deploy/docker/compute/Dockerfile
     env_file:
       - ./environment/common.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
       - ./logs/firecrest:/var/log:delegated
@@ -38,7 +42,9 @@ services:
       dockerfile: deploy/docker/status/Dockerfile
     env_file:
       - ./environment/common.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - ./logs/firecrest:/var/log:delegated
       - ./ssl:/ssl
@@ -50,7 +56,9 @@ services:
     env_file:
       - ./environment/common.env
       - ./environment/storage.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     depends_on:
       - "tasks"
       - "minio"
@@ -75,7 +83,9 @@ services:
       - F7T_STORAGE_TASK_EXP_TIME=2678400
     depends_on:
       - "taskpersistence"
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - ./logs/firecrest:/var/log:delegated
       - ./ssl:/ssl
@@ -86,7 +96,9 @@ services:
       dockerfile: deploy/docker/utilities/Dockerfile
     env_file:
       - ./environment/common.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
       - ./logs/firecrest:/var/log:delegated
@@ -98,7 +110,9 @@ services:
       dockerfile: deploy/docker/reservations/Dockerfile
     env_file:
       - ./environment/common.env
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - "./environment/keys/user-key:/user-key:ro"
       - ./logs/firecrest:/var/log:delegated
@@ -111,8 +125,9 @@ services:
       context: ./
       dockerfile: ./cluster/Dockerfile
     hostname: cluster
-    ports:
-      - "2223:22"
+    networks:
+      - backend
+      - frontend
 
   minio:
     # runs on private network so "cluster" can reach it
@@ -122,13 +137,18 @@ services:
     environment:
       MINIO_ACCESS_KEY: storage_access_key
       MINIO_SECRET_KEY: storage_secret_key
+    networks:
+      - backend
+      - frontend
     ports:
       - "9000:9000"
 
   taskpersistence:
     image: redis:5
     command: redis-server /redis.conf
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - ./taskpersistence/redis.conf:/redis.conf:ro
       - ./logs/firecrest:/var/log:delegated
@@ -136,7 +156,9 @@ services:
   opa:
     image: openpolicyagent/opa:0.22.0
     command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego
-    network_mode: "host"
+    networks:
+      - backend
+      - frontend
     volumes:
       - ./opa:/opa-files
       - ./ssl:/ssl
@@ -146,7 +168,14 @@ services:
     build:
       context: ../../
       dockerfile: ./deploy/docker/openapi/Dockerfile
+    networks:
+      - backend
+      - frontend
     ports:
       - "9090:8080"
     environment:
       SWAGGER_JSON: /tmp/openapi.yaml
+
+networks:
+  backend:
+  frontend:

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -155,7 +155,7 @@ services:
 
   opa:
     image: openpolicyagent/opa:0.22.0
-    command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego
+    command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego --addr http://0.0.0.0:8282
     networks:
       - backend
       - frontend

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -178,4 +178,6 @@ services:
 
 networks:
   backend:
+    name: f7t-backend
   frontend:
+    name: f7t-frontend

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -176,6 +176,9 @@ services:
     environment:
       SWAGGER_JSON: /tmp/openapi.yaml
 
+# For now all containers are attached to both networks.
+# Next step is to split microservices to the
+# correct networks to reflect production reality.
 networks:
   backend:
     name: f7t-backend

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -117,7 +117,7 @@ services:
   minio:
     # runs on private network so "cluster" can reach it
     container_name: minio_test_build
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-02-01T22-56-52Z
     command: minio server /data
     environment:
       MINIO_ACCESS_KEY: storage_access_key

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3'
 
 services:
   certificator:
-    build: 
+    build:
       context: ../../
       dockerfile: deploy/docker/certificator/Dockerfile
     env_file:
@@ -62,7 +62,7 @@ services:
       - ./ssl:/ssl
 
   tasks:
-    build: 
+    build:
       context: ../../
       dockerfile: deploy/docker/tasks/Dockerfile
     env_file:
@@ -76,12 +76,12 @@ services:
     depends_on:
       - "taskpersistence"
     network_mode: "host"
-    volumes: 
+    volumes:
       - ./logs/firecrest:/var/log:delegated
       - ./ssl:/ssl
 
   utilities:
-    build: 
+    build:
       context: ../../
       dockerfile: deploy/docker/utilities/Dockerfile
     env_file:
@@ -93,7 +93,7 @@ services:
       - ./ssl:/ssl
 
   reservations:
-    build: 
+    build:
       context: ../../
       dockerfile: deploy/docker/reservations/Dockerfile
     env_file:
@@ -107,7 +107,7 @@ services:
   # auxiliary containers
   cluster:
     # runs on private network to avoid conflict with a local SSH server
-    build: 
+    build:
       context: ./
       dockerfile: ./cluster/Dockerfile
     hostname: cluster
@@ -124,7 +124,7 @@ services:
       MINIO_SECRET_KEY: storage_secret_key
     ports:
       - "9000:9000"
-    
+
   taskpersistence:
     image: redis:5
     command: redis-server /redis.conf
@@ -137,9 +137,7 @@ services:
     image: openpolicyagent/opa:0.22.0
     command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego
     network_mode: "host"
-    ports: 
-      - "8181:8181"    
-    volumes: 
+    volumes:
       - ./opa:/opa-files
       - ./ssl:/ssl
 

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -25,15 +25,10 @@ F7T_AUTH_ROLE=''
 F7T_DEBUG_MODE=True
 #-------
 # microservices IPs, also defined on each 'env_make' inside containers
-F7T_CERTIFICATOR_IP=127.0.0.1
-F7T_COMPUTE_IP=127.0.0.1
+F7T_COMPUTE_IP=compute
 #TaskPersistence (redis)
-F7T_PERSISTENCE_IP=127.0.0.1
-F7T_TASKS_IP=127.0.0.1
-F7T_STATUS_IP=127.0.0.1
-F7T_STORAGE_IP=127.0.0.1
-F7T_UTILITIES_IP=127.0.0.1
-F7T_RESERVATIONS_IP=127.0.0.1
+F7T_PERSISTENCE_IP=taskpersistence
+F7T_STORAGE_IP=storage
 #----- ports:
 F7T_CERTIFICATOR_PORT=5010
 F7T_COMPUTE_PORT=5000
@@ -44,17 +39,17 @@ F7T_UTILITIES_PORT=5004
 F7T_RESERVATIONS_PORT=5005
 #-------
 # microservices urls: used by Kong and between microservices. Must replace $SERVICE_PORT with the port number
-F7T_CERTIFICATOR_URL=https://127.0.0.1:5010
-F7T_TASKS_URL=https://127.0.0.1:5003
-F7T_COMPUTE_URL=https://127.0.0.1:5000
-F7T_STORAGE_URL=https://127.0.0.1:5002
-F7T_UTILITIES_URL=https://127.0.0.1:5004
-F7T_STATUS_URL=https://127.0.0.1:5001
-F7T_RESERVATIONS_URL=https://127.0.0.1:5005
+F7T_CERTIFICATOR_URL=http://certificator:5010
+F7T_TASKS_URL=http://tasks:5003
+F7T_COMPUTE_URL=http://compute:5000
+F7T_STORAGE_URL=http://storage:5002
+F7T_UTILITIES_URL=http://utilities:5004
+F7T_STATUS_URL=http://status:5001
+F7T_RESERVATIONS_URL=http://reservations:5005
 # kong_url: used by microservices when return URL to clients
 F7T_KONG_URL=
 #-------
-# list of systems 
+# list of systems
 #public name for systems, where users except to submit jobs and get files (list with ';')
 F7T_SYSTEMS_PUBLIC='system01;system02'
 # filesystems mounted in each system
@@ -63,9 +58,9 @@ F7T_SYSTEMS_PUBLIC='system01;system02'
 # FILESYSTEMS = "/home,/scratch;/home"
 F7T_FILESYSTEMS="/home;/home"
 #internal machines that microservices connect to (in correlation with SYSTEMS_PUBLIC)
-F7T_SYSTEMS_INTERNAL_COMPUTE='127.0.0.1:2223;127.0.0.1:2224'
-F7T_SYSTEMS_INTERNAL_STORAGE='127.0.0.1:9000;127.0.0.1:2222'
-F7T_SYSTEMS_INTERNAL_UTILITIES='127.0.0.1:2223;127.0.0.1:2222'
+F7T_SYSTEMS_INTERNAL_COMPUTE='cluster'
+F7T_SYSTEMS_INTERNAL_STORAGE='cluster'
+F7T_SYSTEMS_INTERNAL_UTILITIES='cluster'
 #-------
 # COMPUTE option
 # Base filesystem where job submission files will be stored.
@@ -82,11 +77,11 @@ F7T_STORAGE_MAX_FILE_SIZE=512000
 # Storage technology used for staging area (swift or s3v2 or s3v4, unset to disable)
 F7T_OBJECT_STORAGE='s3v4'
 # set if account is needed for SLURM job submission
-F7T_USE_SLURM_ACCOUNT=True 
+F7T_USE_SLURM_ACCOUNT=True
 #-------
 # STATUS: microservices & systems to pool:
 F7T_STATUS_SERVICES='certificator;utilities;compute;tasks;storage;reservations'
-F7T_STATUS_SYSTEMS='127.0.0.1;127.0.0.1;127.0.0.1;127.0.0.1;127.0.0.1;'
+F7T_STATUS_SYSTEMS='certificator;utilities;compute;tasks;storage;reservations;'
 #-------
 # UTILITIES: max size of file for download/upload from filesystem in MB
 F7T_UTILITIES_MAX_FILE_SIZE=5
@@ -104,10 +99,10 @@ F7T_KONG_TASKS_URL=
 F7T_KONG_UTILITIES_URL=
 # OPA Vars
 F7T_OPA_USE=True
-F7T_OPA_URL=https://localhost:8181
+F7T_OPA_URL=http://opa:8181
 F7T_POLICY_PATH=v1/data/f7t/authz
 # SSL vars
-F7T_USE_SSL=True
+#F7T_USE_SSL=False
 F7T_SSL_CRT=/ssl/f7t_internal.crt
 F7T_SSL_KEY=/ssl/f7t_internal.key
 # F7T_SSL_SIGNED=False

--- a/deploy/test-build/environment/common.env
+++ b/deploy/test-build/environment/common.env
@@ -99,7 +99,7 @@ F7T_KONG_TASKS_URL=
 F7T_KONG_UTILITIES_URL=
 # OPA Vars
 F7T_OPA_USE=True
-F7T_OPA_URL=http://opa:8181
+F7T_OPA_URL=http://opa:8282
 F7T_POLICY_PATH=v1/data/f7t/authz
 # SSL vars
 #F7T_USE_SSL=False

--- a/deploy/test-build/environment/hosts
+++ b/deploy/test-build/environment/hosts
@@ -3,4 +3,3 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-127.0.0.1 minio_test_build

--- a/deploy/test-build/environment/storage.env
+++ b/deploy/test-build/environment/storage.env
@@ -9,7 +9,6 @@ F7T_SWIFT_PASS=
 F7T_SECRET_KEY=
 
 # for S3
-#S3_URL=http://127.0.0.1:9000
 F7T_S3_URL=http://minio_test_build:9000
 F7T_S3_ACCESS_KEY=storage_access_key
 F7T_S3_SECRET_KEY=storage_secret_key
@@ -28,9 +27,9 @@ F7T_XFER_PARTITION=xfer
 
 # external transfers machine (PUBLIC: name, INTERNAL=url or IP internal)
 F7T_EXT_TRANSFER_MACHINE_PUBLIC='system01'
-F7T_EXT_TRANSFER_MACHINE_INTERNAL=127.0.0.1:2223
+F7T_EXT_TRANSFER_MACHINE_INTERNAL=cluster
 
 # Storage polling interval for uploads in seconds
-F7T_STORAGE_POLLING_INTERVAL=60 
+F7T_STORAGE_POLLING_INTERVAL=60
 # Cipher key to encrypt/decrypt certificates
 F7T_CERT_CIPHER_KEY='Df6UZuoPoJ2u5yRwxNfFQ46Nwy8eW1OGTcuhlqn4ONo='

--- a/src/certificator/certificator.py
+++ b/src/certificator/certificator.py
@@ -14,7 +14,6 @@ from logging.handlers import TimedRotatingFileHandler
 import base64
 import requests
 
-STATUS_IP = os.environ.get("F7T_STATUS_IP")
 AUTH_HEADER_NAME = 'Authorization'
 
 AUTH_AUDIENCE = os.environ.get("F7T_AUTH_TOKEN_AUD", '').strip('\'"')
@@ -49,16 +48,16 @@ app = Flask(__name__)
 
 # check user authorization on endpoint
 # using Open Policy Agent
-# 
+#
 # use:
 # check_user_auth(username,system)
 def check_user_auth(username,system):
 
     # check if OPA is active
     if OPA_USE:
-        try: 
+        try:
             input = {"input":{"user": f"{username}", "system": f"{system}"}}
-            
+
             #resp_opa = requests.post(f"{OPA_URL}/{POLICY_PATH}", json=input)
             logging.info(f"{OPA_URL}/{POLICY_PATH}")
 
@@ -71,21 +70,21 @@ def check_user_auth(username,system):
                 return {"allow": True, "description":f"User {username} authorized", "status_code": 200 }
             else:
                 logging.error(f"User {username} NOT authorized by OPA")
-                return {"allow": False, "description":f"Permission denied for user {username} in {system}", "status_code": 401} 
+                return {"allow": False, "description":f"Permission denied for user {username} in {system}", "status_code": 401}
         except requests.exceptions.SSLError as e:
-            logging.error(e.args)               
-            return {"allow": False, "description":"Authorization server error: SSL error.", "status_code": 404} 
+            logging.error(e.args)
+            return {"allow": False, "description":"Authorization server error: SSL error.", "status_code": 404}
         except requests.exceptions.RequestException as e:
             logging.error(e.args)
-            return {"allow": False, "description":"Authorization server error", "status_code": 404} 
-        
+            return {"allow": False, "description":"Authorization server error", "status_code": 404}
+
         except Exception as e:
             logging.error(type(e))
             logging.error(e)
-            
+
             logging.error(e.args)
-            return {"allow": False, "description":"Authorization server error", "status_code": 404} 
-    
+            return {"allow": False, "description":"Authorization server error", "status_code": 404}
+
     return {"allow": True, "description":"Authorization method not active", "status_code": 200 }
 
 # checks JWT from Keycloak, optionally validates signature. It only receives the content of header's auth pair (not key:content)
@@ -108,7 +107,7 @@ def check_header(header):
         # if AUTH_REQUIRED_SCOPE != '':
         #     if not (AUTH_REQUIRED_SCOPE in decoded['realm_access']['roles']):
         #         return False
-        
+
         # {"scope": "openid profile firecrest email"}
         if AUTH_REQUIRED_SCOPE != "":
             if AUTH_REQUIRED_SCOPE not in decoded["scope"].split():
@@ -143,7 +142,7 @@ def get_username(header):
             decoded = jwt.decode(header[7:], verify=False)
         else:
             decoded = jwt.decode(header[7:], realm_pubkey, algorithms=realm_pubkey_type, options={'verify_aud': False})
-        
+
         # check if it's a service account token
         try:
             if AUTH_ROLE in decoded["realm_access"]["roles"]:
@@ -272,15 +271,9 @@ def receive():
 
 
 # get status for status microservice
-# only used by STATUS_IP otherwise forbidden
 @app.route("/status", methods=["GET"])
 def status():
     app.logger.info("Test status of service")
-
-    # if request.remote_addr != STATUS_IP:
-    #     app.logger.warning("Invalid remote address: {addr}".format(addr=request.remote_addr))
-    #     return jsonify(error="Invalid access"), 403
-
     return jsonify(success="ack"), 200
 
 
@@ -315,9 +308,9 @@ if __name__ == "__main__":
 
     # run app
     # debug = False, so output redirects to log files
-    if USE_SSL:        
-        app.run(debug=debug, host='0.0.0.0', port=CERTIFICATOR_PORT, ssl_context=(SSL_CRT, SSL_KEY))        
+    if USE_SSL:
+        app.run(debug=debug, host='0.0.0.0', port=CERTIFICATOR_PORT, ssl_context=(SSL_CRT, SSL_KEY))
     else:
         app.run(debug=debug, host='0.0.0.0', port=CERTIFICATOR_PORT)
-    
+
 

--- a/src/compute/compute.py
+++ b/src/compute/compute.py
@@ -32,7 +32,6 @@ AUTH_HEADER_NAME = 'Authorization'
 
 CERTIFICATOR_URL= os.environ.get("F7T_CERTIFICATOR_URL")
 TASKS_URL       = os.environ.get("F7T_TASKS_URL")
-STATUS_IP       = os.environ.get("F7T_STATUS_IP")
 KONG_URL        = os.environ.get("F7T_KONG_URL")
 
 COMPUTE_PORT    = os.environ.get("F7T_COMPUTE_PORT", 5000)
@@ -79,7 +78,7 @@ def is_jobid(jobid):
             return True
         app.logger.error("Wrong SLURM sbatch return string")
         app.logger.error(f"{jobid} isn't > 0")
-        
+
     except ValueError as e:
         app.logger.error("Wrong SLURM sbatch return string")
         app.logger.error("Couldn't convert to int")
@@ -105,7 +104,7 @@ def extract_jobid(outline):
     if not is_jobid(list_line[-1]):
         # for compatibility reasons if error, returns original string
         return outline
-    
+
     # all clear, conversion is OK
     jobid = int(list_line[-1])
 
@@ -203,7 +202,7 @@ def submit_job_task(auth_header, system_name, system_addr, job_file, job_dir, ta
         app.logger.error(e)
         update_task(task_id, auth_header, async_task.ERROR, e.message)
 
-    
+
 
     #app.logger.info(result)
     return
@@ -278,7 +277,7 @@ def get_slurm_files(auth_header, system_name, system_addr, task_id,job_info,outp
     return control_info
 
 def submit_job_path_task(auth_header,system_name, system_addr,fileName,job_dir, task_id):
-    
+
     try:
         # get scopes from token
         decoded = jwt.decode(auth_header[7:], verify=False)
@@ -301,12 +300,12 @@ def submit_job_path_task(auth_header,system_name, system_addr,fileName,job_dir, 
 
         app.logger.info("scope parameters: " + scopes_parameters)
 
-    
+
     except Exception as e:
         app.logger.error(type(e))
-        
+
         app.logger.error(e.args)
-        
+
 
     action=f"sbatch --chdir={job_dir} {scopes_parameters} -- {fileName}"
 
@@ -328,18 +327,18 @@ def submit_job_path_task(auth_header,system_name, system_addr,fileName,job_dir, 
             return
         err_msg = resp["msg"]
         update_task(task_id, auth_header, async_task.ERROR, err_msg)
-        
+
 
     jobid = extract_jobid(resp["msg"])
 
     msg = {"result":"Job submitted", "jobid":jobid}
 
-    
+
     # now looking for log and err files location
     job_extra_info = get_slurm_files(auth_header, system_name, system_addr, task_id,msg)
 
     update_task(task_id, auth_header,async_task.SUCCESS, job_extra_info,True)
-        
+
 
 ## error handler for files above SIZE_LIMIT -> app.config['MAX_CONTENT_LENGTH']
 @app.errorhandler(413)
@@ -353,9 +352,9 @@ def request_entity_too_large(error):
 @app.route("/jobs/upload",methods=["POST"])
 @check_auth_header
 def submit_job_upload():
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -486,7 +485,7 @@ def submit_job_path():
     except Exception as e:
         data = jsonify(description="Failed to submit job", error="'targetPath' parameter not set in request")
         return data, 400
-    
+
     if targetPath == None:
         data = jsonify(description="Failed to submit job", error="'targetPath' parameter not set in request")
         return data, 400
@@ -495,7 +494,7 @@ def submit_job_path():
         data = jsonify(description="Failed to submit job", error="'targetPath' parameter value is empty")
         return data, 400
 
-    
+
     # checks if targetPath is a valid path for this user in this machine
     check = is_valid_file(targetPath, auth_header, system_name, system_addr)
 
@@ -507,7 +506,7 @@ def submit_job_path():
     # if error in creating task:
     if task_id == -1:
         return jsonify(description="Failed to submit job",error='Error creating task'), 400
-        
+
     # if targetPath = "/home/testuser/test/sbatch.sh/"
     # split by / and discard last element (the file name): ['', 'home', 'testuser', 'test']
     job_dir_splitted = targetPath.split("/")[:-1]
@@ -517,7 +516,7 @@ def submit_job_path():
         job_dir_splitted = job_dir_splitted[:-1]
 
     job_dir = "/".join(job_dir_splitted)
-    
+
 
     try:
         # asynchronous task creation
@@ -607,7 +606,7 @@ def list_jobs():
 
             for jobid in job_aux_list:
                 if not is_jobid(jobid):
-                    return jsonify(error=f"{jobid} is not a valid job ID", description="Failed to retrieve job information"), 400    
+                    return jsonify(error=f"{jobid} is not a valid job ID", description="Failed to retrieve job information"), 400
 
             job_list="--job={jobs}".format(jobs=jobs)
         except:
@@ -624,7 +623,7 @@ def list_jobs():
         # if error in creating task:
         if task_id == -1:
             return jsonify(description="Failed to retrieve job information",error='Error creating task'), 400
-            
+
         update_task(task_id, auth_header, async_task.QUEUED)
 
         # asynchronous task creation
@@ -714,14 +713,14 @@ def list_job_task(auth_header,system_name, system_addr,action,task_id,pageSize,p
     data = jobs
 
     update_task(task_id, auth_header, async_task.SUCCESS, data, True)
-   
+
 
 
 # Retrieves information from a jobid
 @app.route("/jobs/<jobid>",methods=["GET"])
 @check_auth_header
 def list_job(jobid):
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
 
     try:
@@ -772,7 +771,7 @@ def list_job(jobid):
         # if error in creating task:
         if task_id == -1:
             return jsonify(description="Failed to retrieve job information",error='Error creating task'), 400
-            
+
         update_task(task_id, auth_header, async_task.QUEUED)
 
         # asynchronous task creation
@@ -836,7 +835,7 @@ def cancel_job_task(auth_header,system_name, system_addr,action,task_id):
 def cancel_job(jobid):
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -878,7 +877,7 @@ def cancel_job(jobid):
         # if error in creating task:
         if task_id == -1:
             return jsonify(description="Failed to delete job",error='Error creating task'), 400
-            
+
         # asynchronous task creation
         aTask = threading.Thread(target=cancel_job_task,
                              args=(auth_header, system_name, system_addr, action, task_id))
@@ -1028,8 +1027,8 @@ def acct():
         # if error in creating task:
         if task_id == -1:
             return jsonify(description="Failed to retrieve account information",error='Error creating task'), 400
-    
-        
+
+
         update_task(task_id, auth_header, async_task.QUEUED)
 
         # asynchronous task creation
@@ -1046,17 +1045,10 @@ def acct():
         data = jsonify(description="Failed to retrieve account information",error=e)
         return data, 400
 
-# get status for status microservice
-# only used by STATUS_IP otherwise forbidden
 @app.route("/status",methods=["GET"])
 def status():
-
     app.logger.info("Test status of service")
-
-    if request.remote_addr != STATUS_IP:
-        app.logger.warning("Invalid remote address: {addr}".format(addr=request.remote_addr))
-        return jsonify(error="Invalid access"), 403
-
+    # TODO: check compute reservation binary to truthfully respond this request
     return jsonify(success="ack"), 200
 
 
@@ -1078,7 +1070,7 @@ if __name__ == "__main__":
     logger.addHandler(logHandler)
 
     # set debug = False, so output goes to log files
-    if USE_SSL:        
-        app.run(debug=debug, host='0.0.0.0', port=COMPUTE_PORT, ssl_context=(SSL_CRT, SSL_KEY))        
+    if USE_SSL:
+        app.run(debug=debug, host='0.0.0.0', port=COMPUTE_PORT, ssl_context=(SSL_CRT, SSL_KEY))
     else:
         app.run(debug=debug, host='0.0.0.0', port=COMPUTE_PORT)

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -22,7 +22,7 @@ else:
     UTILITIES_URL = os.environ.get("F7T_UTILITIES_URL")
 
 # same server used for utilities and external upload storage
-SERVER_UTILITIES_STORAGE = os.environ.get("F7T_SYSTEMS_PUBLIC").split(";")[0] 
+SERVER_UTILITIES_STORAGE = os.environ.get("F7T_SYSTEMS_PUBLIC").split(";")[0]
 OBJECT_STORAGE = os.environ.get("F7T_OBJECT_STORAGE")
 
 ### SSL parameters
@@ -68,18 +68,15 @@ def test_post_upload_request(headers):
     msg = resp.json()["task"]["data"]["msg"]
     url = msg["url"]
 
-
-    url = url.replace("minio_test_build", "127.0.0.1")
-
     resp = None
-    
+
     if (OBJECT_STORAGE == "s3v2"):
         params = [('AWSAccessKeyId', msg["AWSAccessKeyId"]), ('Signature', msg["Signature"]), ('Expires', msg["Expires"])]
-        
+
         # this way doesn't work
         # files = {'file': ("testsbatch.sh", open(data["sourcePath"], 'rb'))}
         # resp = requests.put(url=url, files=files, params)
-        
+
         # this is the only way signature doesn't break!
         with open(data["sourcePath"], 'rb') as data:
             resp= requests.put(url, data=data, params=params, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
@@ -96,10 +93,10 @@ def test_post_upload_request(headers):
         # swift post request
         params = [('max_file_size', msg["max_file_size"]), ('max_file_count', msg["max_file_count"]), ('expires', msg["expires"]),
         ('signature', msg["signature"]), ('redirect', msg["redirect"])]
-        
+
         with open(data["sourcePath"], 'rb') as data:
             resp= requests.put(url, data=data, params=params, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
-     
+
     assert resp.status_code == 200 or resp.status_code == 204 #TODO: check 204 is right
 
     # download from OS to FS is automatic
@@ -130,7 +127,7 @@ def test_internal_cp(machine, headers):
 
     task_id = resp.json()["task_id"]
     check_task_status(task_id, headers)
-    
+
      # wait to make sure job is finished
     time.sleep(5)
 

--- a/src/tests/automated_tests/readme.txt
+++ b/src/tests/automated_tests/readme.txt
@@ -1,12 +1,16 @@
+***** IMPORTANT *****
+
+Instructions below are for the case where you want to run tests from a local
+python environment. For a containerized environment, please refer to
+ci/dev/README.md.
+
 ***** Install Pytest and dependencies *****
 
-pip3 install -r requirements.txt
-
-
+pip3 install -r deploy/docker/tester/requirements.txt
 
 ***** Configure Test environment *****
 
-The environment variables for your test implementation must be configured 
+The environment variables for your test implementation must be configured
 in the pytest section of pytest.ini file.
 For example, for "test-build" deploy, the configuration is as follows:
 
@@ -72,8 +76,8 @@ Run a specific test within a test file:
 
 ***** Tests Limitations *****
 
-In order to test implementations that are behind a gateway with authetication 
-you will need to disable token verification. This has to be done in your gateway configuration. 
+In order to test implementations that are behind a gateway with authetication
+you will need to disable token verification. This has to be done in your gateway configuration.
 Also you must set to empty the REALM_RSA_PUBLIC_KEY environment variable in the common.env file of your deploy.
 Finally, you will need to specify the firecrest gateway address in FIRECREST_URL environment variable.
 
@@ -87,7 +91,7 @@ You need to setup the following environment variables:
 FIRECREST_URL = http://myapigateway
 
 # enable login with SA
-SA_LOGIN      = True 
+SA_LOGIN      = True
 
 # Openid service url
 SA_TOKEN_URI  = http://myopenidservice/auth/realms/kcrealm/protocol/openid-connect/token
@@ -101,6 +105,6 @@ The "demo" implementation has been configured to be tested using service account
 Open demo.env file to check the configuration values that have been set.
 As previously shown, run the tests on "demo" implementation by executing the following command:
 
-    pytest -c demo.ini 
+    pytest -c demo.ini
 
 

--- a/src/tests/automated_tests/requirements.txt
+++ b/src/tests/automated_tests/requirements.txt
@@ -1,5 +1,7 @@
-pytest
-python-dotenv
-pytest-dotenv
-pyjwt
-requests
+# see with deploy/docker/base/requirements
+PyJWT==1.7.1
+requests==2.22.0
+# dev-specific below:
+pytest==6.2.1
+pytest-dotenv==0.5.2
+pytest-dotenv==0.5.2

--- a/src/tests/automated_tests/test-build.ini
+++ b/src/tests/automated_tests/test-build.ini
@@ -5,3 +5,5 @@ env_files =
     ../../../deploy/test-build/environment/common.env
     ../../../deploy/test-build/environment/storage.env
     test-build.env
+markers =
+    reservations: tests of the reservation feature. Better not overlapped with the rest.

--- a/src/tests/automated_tests/unit/test_unit_areservations.py
+++ b/src/tests/automated_tests/unit/test_unit_areservations.py
@@ -13,6 +13,7 @@ import json
 import datetime
 import time
 
+pytestmark = pytest.mark.reservations
 
 FIRECREST_URL = os.environ.get("FIRECREST_URL")
 if FIRECREST_URL:
@@ -40,18 +41,18 @@ d7 = (datetime.datetime.now() + datetime.timedelta(hours=24)).strftime("%Y-%m-%d
 d8 = (datetime.datetime.now() + datetime.timedelta(hours=25)).strftime("%Y-%m-%dT%H:%M:%S") # wrong format
 
             # parameters:  reservation, account, numberOfNodes, nodeType, starttime, endtime
-POST_DATA = [(SYSTEM, 201, "testrsvok01", "test",  "1", 			"f7t",		d1,		d2), 
-		     (SYSTEM, 201, "testrsvok02", "test",  "1", 			"f7t",		d5,		d6), 
+POST_DATA = [(SYSTEM, 201, "testrsvok01", "test",  "1", 			"f7t",		d1,		d2),
+		     (SYSTEM, 201, "testrsvok02", "test",  "1", 			"f7t",		d5,		d6),
              (SYSTEM, 400, "testrsvok01", "test",  "1", 			"f7t",		d1,		d2), # fail, duplicated reservation name
 			 (SYSTEM, 400, "testrsverr02", "test", "1", "f7t",d2,d1), # fail: dates are in wrong order
              (SYSTEM, 400, "testrsverr03", "test", "1", "intel",d2,d1), # fail: invalid nodeType
-			 (SYSTEM, 400, "testrsverr04", "test", "1", "f7t",d3,d4), # fail: wrong date time format             
+			 (SYSTEM, 400, "testrsverr04", "test", "1", "f7t",d3,d4), # fail: wrong date time format
 			 (SYSTEM, 400, "",            "test", "1", "f7t",d5,d6), # fail: no reservation name
 			 (SYSTEM, 400, "testrsverr05", None, "1", "f7t",d5,d6), # fail: no account given
 			 (SYSTEM, 400, "testrsverr06", "test", "3", "f7t",d5,d6), # fail: required more nodes than available
 			 (SYSTEM, 400, "testrsverr07", "test", "1", None,d5,d6), # fail: no nodeType given
 			 (SYSTEM, 400, "testrsverr08", None, "1", "f7t",None,d6), # fail: no starttime given
-			 (SYSTEM, 400, "testrsverr09", None, "1", "f7t",d5,None), # fail: no endtime given			 
+			 (SYSTEM, 400, "testrsverr09", None, "1", "f7t",d5,None), # fail: no endtime given
 ]
 
 # parameters:                reservation, numberOfNodes, nodeType, starttime, endtime
@@ -59,14 +60,14 @@ PUT_DATA =  [(SYSTEM, 400, "testrsvok01", "1", 			"f7t",		d5,		d6), # fail overl
 			 (SYSTEM, 200, "testrsvok01", "1", 			"f7t",		d7,		d8), # ok
              (SYSTEM, 400, "testrsvok01", "1", "f7t",d2,d1), # fail: dates are in wrong order
              (SYSTEM, 400, "testrsvok01", "1", "intel",d5,d6), # fail: invalid nodeType
-			 (SYSTEM, 400, "testrsvok01", "1", "f7t",d3,d4), # fail: wrong date time format             
+			 (SYSTEM, 400, "testrsvok01", "1", "f7t",d3,d4), # fail: wrong date time format
 			 (SYSTEM, 405, "",            "1", "f7t",d5,d6), # fail: no reservation name, method not allowed
 			 (SYSTEM, 400, "wrongname",   "1", "f7t",d5,d6), # fail: wrong reservation name
 			 (SYSTEM, 400, "testrsvok01", "3", "f7t",d5,d6), # fail: required more nodes than available
 			 (SYSTEM, 400, "testrsvok01", "1", None,d5,d6), # fail: no nodeType given
 			 (SYSTEM, 400, "testrsvok01", "1", "f7t",None,d6), # fail: no starttime given
 			 (SYSTEM, 400, "testrsvok01", "1", "f7t",d5,None), # fail: no endtime given
-			 
+
 ]
 
 
@@ -83,14 +84,14 @@ SSL_PATH = "../../../deploy/test-build"
 
 
 @pytest.mark.parametrize("system,status_code",LIST_DATA)
-def test_list_reservation(system, status_code, headers):	
+def test_list_reservation(system, status_code, headers):
 	url = RESERVATIONS_URL
 	headers["X-Machine-Name"] = system
 	resp = requests.get(url, headers=headers, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
 	print(resp.content)
 	print(resp.headers)
 	assert resp.status_code == status_code
-	 
+
 
 @pytest.mark.parametrize("system,status_code,reservation,account,numberOfNodes,nodeType,starttime,endtime",POST_DATA)
 def test_post_reservation(system, status_code,reservation,account,numberOfNodes,nodeType,starttime,endtime,headers):
@@ -118,7 +119,7 @@ def test_put_reservation(system, status_code,reservation,numberOfNodes,nodeType,
 def test_delete_reservation(system, status_code,reservation,headers):
 	url = f"{RESERVATIONS_URL}/{reservation}"
 	headers["X-Machine-Name"] = system
-	
+
 	resp = requests.delete(url, headers=headers, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
 	print(resp.content)
 	print(resp.headers)

--- a/src/utilities/utilities.py
+++ b/src/utilities/utilities.py
@@ -19,7 +19,6 @@ import io
 
 
 CERTIFICATOR_URL = os.environ.get("F7T_CERTIFICATOR_URL")
-STATUS_IP        = os.environ.get("F7T_STATUS_IP")
 
 UTILITIES_PORT   = os.environ.get("F7T_UTILITIES_PORT", 5000)
 
@@ -54,7 +53,7 @@ app.config['MAX_CONTENT_LENGTH'] = int(MAX_FILE_SIZE) * 1024 * 1024
 @app.route("/file", methods=["GET"])
 @check_auth_header
 def file_type():
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
 
     try:
@@ -113,7 +112,7 @@ def file_type():
 def chmod():
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -176,7 +175,7 @@ def chmod():
 @app.route("/chown",methods=["PUT"])
 @check_auth_header
 def chown():
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
 
     try:
@@ -234,7 +233,7 @@ def chown():
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
 
-        
+
     return jsonify(description="Operation completed", out=retval["msg"]), 200
 
 
@@ -247,7 +246,7 @@ def chown():
 @app.route("/ls",methods=["GET"])
 @check_auth_header
 def list_directory():
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
 
     try:
@@ -299,7 +298,7 @@ def list_directory():
             jsonify(description=ret_data["description"], error=ret_data["error"]), ret_data["status_code"], ret_data["header"]
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
-        
+
     # file List is retorned as a string separated for a $ character
     fileList = []
     if len(retval["msg"].split("$")) == 1:
@@ -385,7 +384,7 @@ def list_directory():
 def make_directory():
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -405,7 +404,7 @@ def make_directory():
         path = request.form["targetPath"]
         if path == "":
             return jsonify(description="Error creating directory",error="'targetPath' value is empty"), 400
-        
+
     except BadRequestKeyError:
         return jsonify(description="Error creating directory", error="'targetPath' query string missing"), 400
 
@@ -431,7 +430,7 @@ def make_directory():
             jsonify(description=ret_data["description"], error=ret_data["error"]), ret_data["status_code"], ret_data["header"]
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
-        
+
     return jsonify(description="Directory created", output=""), 201
 
 ## Returns the content from the specified path on the {machine} filesystem
@@ -485,9 +484,9 @@ def view():
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
 
-    
+
     file_size = int(retval["msg"]) # in bytes
-    max_file_size = MAX_FILE_SIZE*(1024*1024) 
+    max_file_size = MAX_FILE_SIZE*(1024*1024)
 
 
     if file_size > max_file_size:
@@ -516,11 +515,11 @@ def view():
     content = retval["msg"].replace("$","\n")
 
     return jsonify(description="File content successfully returned", output=content), 200
-    
+
 
 ## checksum: Print or check SHA256 (256-bit) checksums
 ## params:
-##  - targetPath: Filesystem path (Str) *required##  
+##  - targetPath: Filesystem path (Str) *required##
 ##  - machinename: str *required
 
 @app.route("/checksum",methods=["GET"])
@@ -528,7 +527,7 @@ def view():
 def checksum():
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -548,7 +547,7 @@ def checksum():
         path = request.args.get("targetPath")
         if path == "":
             return jsonify(description="Error obatining checksum",error="'targetPath' value is empty"), 400
-        
+
     except BadRequestKeyError:
         return jsonify(description="Error obatining checksum", error="'targetPath' query string missing"), 400
 
@@ -572,7 +571,7 @@ def checksum():
 
     # on success: retval["msg"] = "checksum  /path/to/file"
     output = retval["msg"].split()[0]
-    
+
 
     return jsonify(description="Checksum successfully retrieved", output=output), 200
 
@@ -601,7 +600,7 @@ def copy():
 
 ## common code for file operations: copy, rename (move)
 def common_operation(request, command, method):
-    
+
     auth_header = request.headers[AUTH_HEADER_NAME]
 
     try:
@@ -660,7 +659,7 @@ def common_operation(request, command, method):
             jsonify(description=ret_data["description"], error=ret_data["error"]), ret_data["status_code"], ret_data["header"]
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
-        
+
     return jsonify(description="Success to " + command + " file or directory.", output=""), success_code
 
 
@@ -675,7 +674,7 @@ def common_operation(request, command, method):
 def rm():
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -694,7 +693,7 @@ def rm():
     try:
         path = request.form["targetPath"]
         if path == "":
-            return jsonify(description="Error on delete operation",error="'targetPath' value is empty"), 400    
+            return jsonify(description="Error on delete operation",error="'targetPath' value is empty"), 400
     except BadRequestKeyError:
         return jsonify(description="Error on delete operation",error="'targetPath' query string missing"), 400
 
@@ -716,7 +715,7 @@ def rm():
             jsonify(description=ret_data["description"], error=ret_data["error"]), ret_data["status_code"], ret_data["header"]
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
-       
+
     return jsonify(description="Success to delete file or directory.", output=""), 204
 
 
@@ -732,7 +731,7 @@ def rm():
 def symlink():
 
     auth_header = request.headers[AUTH_HEADER_NAME]
-    
+
     try:
         system_name = request.headers["X-Machine-Name"]
     except KeyError as e:
@@ -778,7 +777,7 @@ def symlink():
             jsonify(description=ret_data["description"], error=ret_data["error"]), ret_data["status_code"], ret_data["header"]
         except:
             return jsonify(description=ret_data["description"]), ret_data["status_code"], ret_data["header"]
-        
+
     return jsonify(description="Success create the symlink"), 201
 
 
@@ -926,16 +925,9 @@ def upload():
     return jsonify(description="File upload successful"), 201
 
 
-# get status for status microservice
-# only used by STATUS_IP otherwise forbidden
 @app.route("/status", methods=["GET"])
 def status():
     app.logger.info("Test status of service")
-
-    if request.remote_addr != STATUS_IP:
-        app.logger.warning("Invalid remote address: {addr}".format(addr=request.remote_addr))
-        return jsonify(error="Invalid access"), 403
-
     return jsonify(success="ack"), 200
 
 
@@ -957,7 +949,7 @@ if __name__ == "__main__":
 
     # run app
     # debug = False, so output redirects to log files
-    if USE_SSL:        
-        app.run(debug=debug, host='0.0.0.0', port=UTILITIES_PORT, ssl_context=(SSL_CRT, SSL_KEY))        
+    if USE_SSL:
+        app.run(debug=debug, host='0.0.0.0', port=UTILITIES_PORT, ssl_context=(SSL_CRT, SSL_KEY))
     else:
         app.run(debug=debug, host='0.0.0.0', port=UTILITIES_PORT)


### PR DESCRIPTION
This PR aims to ease the process of contributing new tests to firecrest.
- Get the same experience on developers' laptop and on Jenkins CI  (see [ci/dev/README.md](https://github.com/eth-cscs/firecrest/tree/RESTAPI-601-testing-bonus/ci/dev))
- Simplify `Jenkinsfile` with a friendlier declarative approach and less business logic within
- Containerize the testing environment and leverage on docker-compose networks for the sake of portability and reproducibility
- Pin versions of dependencies to avoid issues when images are re-created, removing duplication as much as possible.
- Minor fixes to improve error messages I came across when trying to reproduce the Jenkins tests runs on my laptop

**NOTE:** With this MR merged, we'll switch to [Jenkins multibranch pipelines](https://www.jenkins.io/doc/book/pipeline/multibranch/) to better support scaling of feature branch jobs and dynamic pickup of Jenkinsfiles from the branch being built. Let's sync the update of the Jenkins configs.

Suggested next steps (for other PRs):
- Add a linter check and fix all files at once
- Avoid the arbitrary sleep for containers startup and wait for a "readinessProbe" of the main f7t API (requires implementation of status endpoints)
- Fix / discuss `USE_SSL` issue (it's missing a cast to bool. Could be re-enabled for testing env if required)
- Refactor: apply the approach of this PR to "demo/pre-prod" tests and profit
- Enhance reservation tests leveraging on pytest mark and different docker-compose stacks (to avoid tests execution order dependencies)