### PR TITLE
Restapi 610 reformat the response of an external upload task

### DIFF
--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -124,7 +124,6 @@ services:
   opa:
     image: openpolicyagent/opa:0.22.0
     command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego
-    # network_mode: "host"
     ports: 
       - "8181:8181"    
     volumes: 
@@ -132,7 +131,6 @@ services:
       - ./ssl:/ssl
 
   openapi:
-    # image: swaggerapi/swagger-ui:v3.22.0
     build:
       context: ../../
       dockerfile: ./deploy/docker/openapi/Dockerfile

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -124,7 +124,7 @@ services:
   opa:
     image: openpolicyagent/opa:0.22.0
     command: run --server --log-level=debug --log-format=json-pretty --tls-cert-file=/ssl/f7t_internal.crt --tls-private-key-file=/ssl/f7t_internal.key /opa-files/data.json /opa-files/policy.rego
-    network_mode: "host"
+    # network_mode: "host"
     ports: 
       - "8181:8181"    
     volumes: 

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -307,35 +307,32 @@ class S3v2(ObjectStorage):
 
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
-
-        # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
-
-        # print("(result sig: {})".format(sig))
-
-        # msg = "curl -i -X POST {url}/{containername}/{prefix} -F AWSAccessKeyId={awsAccessKeyId} -F Signature={signature} " \
-        #       "-F Expires={expires} -F file=@{file}".format(
-        #     url=self.url, containername=containername, prefix=prefix,
-        #     awsAccessKeyId=self.user, signature=sig, expires=expires,file=sourcepath)
-
+        
         url = "{url}/{containername}/{prefix}/{objectname}".format(
             url=self.url, containername=containername, prefix=prefix, objectname=objectname)
 
-        data = {}
-        #
-        data["url"] = url
-        data["method"] = httpVerb
-        data["AWSAccessKeyId"] = self.user
-        data["Signature"] = sig
-        data["Expires"] = expires
-        data["sourcepath"] = sourcepath
+        retval = {}
 
-        command = "curl -i -X {httpVerb} '{url}?AWSAccessKeyId={AWSAccessKeyId}&Signature={Signature}&Expires={Expires}' -T {sourcepath}".format(
-            httpVerb=httpVerb, sourcepath=sourcepath, url=url, AWSAccessKeyId=data["AWSAccessKeyId"],
-            Signature=urllib.parse.quote(data["Signature"]), Expires=data["Expires"])
+        retval["parameters"] = {
+            
+            "url": url,
+            "method": httpVerb,
+            "params": {
+                "AWSAccessKeyId": self.user,
+                "Signature": sig,
+                "Expires": expires
+            },
+            "files": sourcepath,
+            "json": {},
+            "data": {},
+            "headers": {}
+        }
 
-        data["command"] = command
+        command = f"curl -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
+        
+        retval["command"] = command
 
-        return data
+        return retval
 
     def create_temp_url(self, containername, prefix, objectname, ttl):
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -380,28 +380,38 @@ class S3v4(ObjectStorage):
 
         signature = hmac.new(signing_key, base64Policy.encode('utf-8'), hashlib.sha256).hexdigest()
 
-        fields = {
-            "key": prefix + "/" + objectname,
-            "x-amz-algorithm": algorithm,
-            "x-amz-credential": credentials,
-            "x-amz-date": amzdate,
-            "policy": base64Policy,
-            "x-amz-signature" : signature
+
+        retval = {}
+
+        retval["parameters"] = {
+
+            "method": httpVerb,
+            "url": f"{endpoint_url}/{containername}",
+            "data": {
+                "key": prefix + "/" + objectname,
+                "x-amz-algorithm": algorithm,
+                "x-amz-credential": credentials,
+                "x-amz-date": amzdate,
+                "policy": base64Policy,
+                "x-amz-signature" : signature
+            },
+            "files": sourcepath,
+            "json" : {},
+            "params": {},
+            "headers": {}
         }
 
         command = f"curl -i -X {httpVerb} {endpoint_url}/{containername}"
 
-        for k,v in fields.items():
+        for k,v in retval["parameters"]["data"].items():
             command += f" -F '{k}={v}'"
 
-        command+=f" -F file=@{sourcepath}"
+        command+=f" -F file=@{retval['parameters']['files']}"
 
-        fields["command"] = command
-        fields["method"]  = httpVerb
-        fields["url"] = f"{endpoint_url}/{containername}"
+        retval["command"] = command
 
-        return fields
-
+        return retval
+        
 
     def create_temp_url(self, containername, prefix, objectname, ttl):
 

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -224,30 +224,34 @@ class Swift(ObjectStorage):
         signature = hmac.new(secret, hmac_body, sha1).hexdigest()
 
         # added OBJECT_PREFIX as dir_[task_id] in order to become unique the upload instead of user/filename
-        command = "curl -i {swift_url}/{swift_api_version}/{swift_account}/{containername}/{prefix}/" \
-              " -X POST " \
-              "-F max_file_size={max_file_size} -F max_file_count={max_file_count} " \
-              "-F expires={expires} -F signature={signature} " \
-              "-F redirect={redirect} -F file=@{sourcepath} ".format(
-            swift_url=swift_url, swift_api_version=swift_version, swift_account=swift_account,
-            containername=containername, prefix=prefix, max_file_size=max_file_size,
-            max_file_count=max_file_count,
-            expires=expires, signature=signature, redirect=redirect, sourcepath=sourcepath)
+        command = f"curl -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
+              f" -X POST " \
+              f"-F max_file_size={max_file_size} -F max_file_count={max_file_count} " \
+              f"-F expires={expires} -F signature={signature} " \
+              f"-F redirect={redirect} -F file=@{sourcepath} "
 
 
+        retval = {}
 
-        retval = dict()
+        retval["parameters"] = {
+            "method": "POST",
+            "url": f"{swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/",
+            "data": {
+                "max_file_size": max_file_size, 
+                "max_file_count": max_file_count,
+                "expires": expires,
+                "signature": signature,
+                "redirect": redirect,
+            },
+            "files": sourcepath,
+            "json": {},
+            "headers": {},
+            "params": {}
 
-        retval["method"] = "POST"
+        }
+
         retval["command"] = command
-        retval["url"] = "{swift_url}/{swift_api_version}/{swift_account}/{containername}/{prefix}/".format(swift_url=swift_url, swift_api_version=swift_version, swift_account=swift_account,
-            containername=containername, prefix=prefix)
-        retval["max_file_size"] = max_file_size
-        retval["max_file_count"] = max_file_count
-        retval["expires"] = expires
-        retval["signature"] = signature
-        retval["redirect"] = redirect
-        retval["sourcepath"] = sourcepath
+        
 
         return retval
 

--- a/src/tests/automated_tests/integration/test_storage.py
+++ b/src/tests/automated_tests/integration/test_storage.py
@@ -66,7 +66,7 @@ def test_post_upload_request(headers):
 
     # upload file to storage server
     msg = resp.json()["task"]["data"]["msg"]
-    url = msg["url"]
+    url = msg["parameters"]["url"]
 
 
     url = url.replace("minio_test_build", "127.0.0.1")
@@ -74,7 +74,7 @@ def test_post_upload_request(headers):
     resp = None
     
     if (OBJECT_STORAGE == "s3v2"):
-        params = [('AWSAccessKeyId', msg["AWSAccessKeyId"]), ('Signature', msg["Signature"]), ('Expires', msg["Expires"])]
+        params = [('AWSAccessKeyId', msg["parameters"]["params"]["AWSAccessKeyId"]), ('Signature', msg["parameters"]["params"]["Signature"]), ('Expires', msg["parameters"]["params"]["Expires"])]
         
         # this way doesn't work
         # files = {'file': ("testsbatch.sh", open(data["sourcePath"], 'rb'))}
@@ -85,9 +85,9 @@ def test_post_upload_request(headers):
             resp= requests.put(url, data=data, params=params, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))
 
     elif (OBJECT_STORAGE == "s3v4"):
-        post_data =  [('key', msg["key"]), ('policy', msg["policy"]), ('x-amz-algorithm', msg["x-amz-algorithm"])
-        , ('x-amz-credential', msg["x-amz-credential"]), ('x-amz-date', msg["x-amz-date"]),
-        ('x-amz-signature', msg["x-amz-signature"])]
+        post_data =  [('key', msg["parameters"]["data"]["key"]), ('policy', msg["parameters"]["data"]["policy"]), ('x-amz-algorithm', msg["parameters"]["data"]["x-amz-algorithm"])
+        , ('x-amz-credential', msg["parameters"]["data"]["x-amz-credential"]), ('x-amz-date', msg["parameters"]["data"]["x-amz-date"]),
+        ('x-amz-signature', msg["parameters"]["data"]["x-amz-signature"])]
 
         files = {'file': open(data["sourcePath"],'rb')}
         resp = requests.post(url, data=post_data, files=files, verify= (f"{SSL_PATH}{SSL_CRT}" if USE_SSL else False))

--- a/src/tests/automated_tests/requirements.txt
+++ b/src/tests/automated_tests/requirements.txt
@@ -1,5 +1,5 @@
-pytest
-python-dotenv
-pytest-dotenv
-pyjwt
-requests
+pytest == 5.3.4
+python-dotenv == 0.10.5
+pytest-dotenv == 0.4.0
+pyjwt == 1.7.1
+requests == 2.22.0


### PR DESCRIPTION
- New format for `"msg"` field in tasks related to `xfer-external/upload` endpoint
  - Now output has a `"parameter"` field that gathers parameters for `requests` library in order to create upload to staging area using this library for SWIFT, s3v4 and s3v2.
- Also,
  - Removed "host" network in demo OPA since is deprecated in `docker-compose` >= 1.28
  - Fixed python modules version needed for automated tests (this fixes pipeline errors)