### PR TITLE
local f7t-base: push removed

### DIFF
--- a/ci/pre-prod/build_image_role/tasks/main.yml
+++ b/ci/pre-prod/build_image_role/tasks/main.yml
@@ -45,8 +45,7 @@
       path: /home/firecrest/awx-firecrest-build
       dockerfile: ./deploy/docker/base/Dockerfile
     source: build
-    state: present
-    push: yes
+    state: present    
 
 - name: build container image
   docker_image:


### PR DESCRIPTION
Removed `push` option on `f7t-base` local image