### PR TITLE
Avoid pull of local base-image

### DIFF
--- a/ci/pre-prod/build_image_role/tasks/main.yml
+++ b/ci/pre-prod/build_image_role/tasks/main.yml
@@ -18,34 +18,38 @@
     dest: /home/firecrest/awx-firecrest-build
     version: "{{ commit_id }}"
 
-- name: build base image with build tag 
+- name: build base image with build tag
   docker_image:
     name: "localhost:5000/f7t-base:{{ build_tag }}"
     build:
       path: /home/firecrest/awx-firecrest-build
       dockerfile: ./deploy/docker/base/Dockerfile
+      pull: yes
     source: build
     state: present
-    push: yes  
+    push: yes
 
-- name: build base image with latest tag 
+# TODO: Building because tagging didn't seem to be properly tagging
+- name: build base image with latest tag
   docker_image:
     name: "localhost:5000/f7t-base:latest"
     build:
       path: /home/firecrest/awx-firecrest-build
       dockerfile: ./deploy/docker/base/Dockerfile
+      pull: yes
     source: build
     state: present
     push: yes
 
-- name: build base image locally 
+- name: build base image locally
   docker_image:
     name: "f7t-base"
     build:
       path: /home/firecrest/awx-firecrest-build
       dockerfile: ./deploy/docker/base/Dockerfile
+      pull: yes
     source: build
-    state: present    
+    state: present
 
 - name: build container image
   docker_image:
@@ -53,6 +57,8 @@
     build:
       path: /home/firecrest/awx-firecrest-build
       dockerfile: ./deploy/docker/{{ item.key }}/Dockerfile
+      # Pull no, because base image is built locally for now
+      pull: no
     source: build
     state: present
     push: yes
@@ -64,6 +70,7 @@
     build:
       path: /home/firecrest/awx-firecrest-build/src/tests/template_client
       dockerfile: ./Dockerfile
+      pull: yes
     source: build
     state: present
     push: yes


### PR DESCRIPTION
Until registries configs are fixed, avoid pulling from (remote) default registry a locally-built image.