### PR TITLE
Restapi 621 dependency security issue in cryptography package

### DIFF
--- a/deploy/docker/base/requirements.txt
+++ b/deploy/docker/base/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==2.8
+cryptography==3.4.6
 Flask==1.1.2
 PyJWT==1.7.1
 requests==2.22.0

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta2
+  version: 1.7.1-beta3
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta2
+  version: 1.7.1-beta3
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a


### PR DESCRIPTION
- Updated `cryptography`package to `3.4.6`
- Updated version in openapi specification