### PR TITLE
Restapi 622 error at marking objects with x delete after

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta2
+  version: 1.7.1-beta4
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta2
+  version: 1.7.1-beta4
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -666,7 +666,7 @@ class S3v4(ObjectStorage):
             resp = requests.put(url, data=body, headers=headers)
 
             if resp.ok:
-                logging.info("Object marked as delete-at succesfully")
+                logging.info(f"Object was marked as to be deleted at {_delete_at_iso}")
 
                 return 0
             

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -376,9 +376,9 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
     retval = staging.delete_object_after(containername=container_name,prefix=object_prefix,objectname=object_name,ttl=int(time.time()) + STORAGE_TEMPURL_EXP_TIME)
 
     if retval == 0:
-        app.logger.info("Setting {seconds} [s] as X-Delete-After".format(seconds=STORAGE_TEMPURL_EXP_TIME))
+        app.logger.info("Setting {seconds} [s] as X-Delete-At".format(seconds=STORAGE_TEMPURL_EXP_TIME))
     else:
-        app.logger.error("Object couldn't be marked as X-Delete-After")
+        app.logger.error("Object couldn't be marked as X-Delete-At")
 
 
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -214,7 +214,7 @@ def os_to_fs(task_id):
             # Therefore, using delete_object_after a few minutes (in this case 5 minutes) will trigger internal staging area
             # mechanism to delete the file automatically and without a need of a connection
 
-            staging.delete_object_after(containername=username,prefix=task_id,objectname=objectname, ttl = time.time()+600)
+            staging.delete_object_after(containername=username,prefix=task_id,objectname=objectname, ttl = int(time.time())+600)
 
         # if error, should be prepared for try again
         else:
@@ -463,7 +463,7 @@ def invalidate_request():
 
         # error = staging.delete_object(containername,prefix,objectname)
         # replacing delete_object by delete_object_after 5 minutes
-        error = staging.delete_object_after(containername=containername, prefix=prefix, objectname=objectname, ttl=time.time()+600)
+        error = staging.delete_object_after(containername=containername, prefix=prefix, objectname=objectname, ttl=int(time.time())+600)
 
         if error == -1:
             return jsonify(error="Could not invalidate URL"), 400

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -372,7 +372,8 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
 
     # if succesfully created: temp_url in task with success status
     update_task(task_id, auth_header, async_task.ST_UPL_END, temp_url)
-    retval = staging.delete_object_after(containername=container_name,prefix=object_prefix,objectname=object_name,ttl=STORAGE_TEMPURL_EXP_TIME)
+    # marked deletion from here to STORAGE_TEMPURL_EXP_TIME (default 30 days)
+    retval = staging.delete_object_after(containername=container_name,prefix=object_prefix,objectname=object_name,ttl=int(time.time()) + STORAGE_TEMPURL_EXP_TIME)
 
     if retval == 0:
         app.logger.info("Setting {seconds} [s] as X-Delete-After".format(seconds=STORAGE_TEMPURL_EXP_TIME))

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -9,6 +9,7 @@ import logging
 import requests
 import keystone
 from time import time
+from datetime import datetime
 import hmac
 from hashlib import sha1
 
@@ -138,6 +139,7 @@ class Swift(ObjectStorage):
 
         try:
             req = requests.head(url, headers={"X-Auth-Token": self.auth})
+            logging.info(req.headers)
             headers = req.headers
 
             # if Content-Lenght == 0, then object doesn't exist
@@ -292,23 +294,26 @@ class Swift(ObjectStorage):
     # sets time to live (TTL) for an object in SWIFT
     def delete_object_after(self,containername,prefix,objectname,ttl):
 
-        swift_account_url = "{swift_url}/{containername}/{prefix}/{objectname}".format(
-            swift_url=self.url, containername=containername, prefix=prefix, objectname=objectname)
+        swift_account_url = f"{self.url}/{containername}/{prefix}/{objectname}"
 
-        header = {'X-Delete-After': "{}".format(ttl), "X-Auth-Token": self.auth}
+        header = {"X-Delete-At": str(ttl), "X-Auth-Token": self.auth}
 
         try:
-            logging.info("Setting {seconds} [s] as X-Delete-After".format(seconds=ttl))
+            logging.info(f"Setting {ttl} [s] as X-Delete-At")
 
             req = requests.post(swift_account_url, headers=header)
 
             if not req.ok:
-                logging.error("Object couldn't be marked as X-Delete-After")
+                logging.error("Object couldn't be marked as X-Delete-At")
+                logging.error(req.text)
                 return -1
+            date_ttl = datetime.fromtimestamp(ttl).strftime("%Y-%m-%dT%H:%M:%S")
+
+            logging.info(f"Object was marked as to be deleted at {date_ttl}")
             return 0
 
         except Exception as e:
-            logging.error("Object couldn't be marked as X-Delete-After")
+            logging.error("Object couldn't be marked as X-Delete-At")
             logging.error(e)
             return -1
 
@@ -321,7 +326,7 @@ class Swift(ObjectStorage):
 
         try:
 
-            logging.info("Deleting object: {}/{}/{}".format(containername,prefix,objectname))
+            logging.info(f"Deleting object: {containername}/{prefix}/{objectname}")
 
             req = requests.delete(swift_account_url, headers=header)
 


### PR DESCRIPTION
In `swiftOS.py` changed deletion from `X-Delete-After` to `X-Delete-At`(as explained [here](https://docs.openstack.org/api-ref/object-store/?expanded=create-or-update-object-metadata-detail#create-or-update-object-metadata))
- Casting seconds to int (error was raised for the use of floats comming from `time.time()` function)
- Changed version of the API