### PR TITLE
Restapi 626 adapt keystone for new oidc auth method (v1.7.2-beta1)

### DIFF
--- a/src/storage/keystone.py
+++ b/src/storage/keystone.py
@@ -4,88 +4,25 @@
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause
 #
-from keystoneauth1.identity import v3
-from keystoneauth1 import session as keystonesession
-from keystoneauth1 import exceptions as keystoneexception
-from keystoneauth1.extras._saml2 import V3Saml2Password
-
-import logging
-import requests
-import os
+from abc import ABCMeta,abstractmethod
 
 
-OS_AUTH_URL             = os.environ.get("F7T_OS_AUTH_URL")
-OS_IDENTITY_PROVIDER    = os.environ.get("F7T_OS_IDENTITY_PROVIDER")
-OS_IDENTITY_PROVIDER_URL= os.environ.get("F7T_OS_IDENTITY_PROVIDER_URL")
-OS_PROTOCOL             = os.environ.get("F7T_OS_PROTOCOL")
-OS_INTERFACE            = os.environ.get("F7T_OS_INTERFACE")
-OS_PROJECT_ID           = os.environ.get("F7T_OS_PROJECT_ID")
+class Keystone:
+    __metaclass__ = ABCMeta
+
+    # default constructor
+    @abstractmethod
+    def __init__(self,url):
+        pass
+
+    # returns a valid token if username & password are valid keystone credentials
+    @abstractmethod
+    def authenticate(username,password):
+        pass
+
+    # Checks if token is valid directly with keystone API
+    @abstractmethod
+    def is_token_valid(token):
+        pass
 
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger(__name__)
-
-# returns a valid token if username & password are valid keystone credentials
-def authenticate(username,password):
-
-    try:
-
-        auth = V3Saml2Password(auth_url=OS_AUTH_URL, identity_provider=OS_IDENTITY_PROVIDER, protocol=OS_PROTOCOL,
-                               identity_provider_url=OS_IDENTITY_PROVIDER_URL, username=username, password=password)
-
-
-
-        sess = keystonesession.Session(auth=auth)
-        try:
-
-            log.info(sess.get_token())
-        except AttributeError as e:
-            log.info(e)
-            log.info(e.args)
-
-
-        auth = v3.token.Token(auth_url=OS_AUTH_URL, token=sess.get_token(), project_id=OS_PROJECT_ID)
-
-        sess = keystonesession.Session(auth=auth)
-
-        OS_TOKEN = sess.get_token()
-
-        return {"error":0,"OS_TOKEN":OS_TOKEN}
-
-    except keystoneexception.http.BadRequest as e:
-        log.error(e)
-        log.error(e.message)
-        log.error(e.details)
-        return {"error":1,"msg":e.message}
-
-
-    except Exception as e:
-
-        log.error(type(e))
-        return {"error":1,"msg":e}
-
-
-# Checks if token is valid directly with keystone API
-def is_token_valid(token):
-
-    url = "{os_auth_url}/auth/tokens".format(os_auth_url=OS_AUTH_URL)
-
-    headers = {"X-Auth-Token":token,
-               "X-Subject-Token":token}
-
-    try:
-
-        r = requests.get(url=url,headers=headers)
-
-        if r.status_code == 200:
-            logging.info("Valid token")
-            return True
-
-        logging.warning("Invalid token")
-
-        return False
-
-    except requests.exceptions.RequestException as re:
-        logging.error(re)
-        logging.error("Invalid token request")
-        return False

--- a/src/storage/keystoneoidc.py
+++ b/src/storage/keystoneoidc.py
@@ -1,0 +1,107 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+from keystoneauth1.identity import v3
+from keystoneauth1 import session as keystonesession
+from keystoneauth1 import exceptions as keystoneexception
+from keystoneauth1.identity import V3OidcPassword
+
+import logging
+import requests
+import os
+from keystone import Keystone
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+class KeystoneOIDC(Keystone):
+
+    def __init__(self):
+        self.OS_AUTH_URL             = os.environ.get("F7T_OS_AUTH_URL")
+        self.OS_IDENTITY_PROVIDER    = os.environ.get("F7T_OS_IDENTITY_PROVIDER")
+        self.OS_PROTOCOL             = os.environ.get("F7T_OS_PROTOCOL")
+        self.OS_INTERFACE            = os.environ.get("F7T_OS_INTERFACE")
+        self.OS_PROJECT_ID           = os.environ.get("F7T_OS_PROJECT_ID")
+        self.OS_CLIENT_ID            = os.environ.get("F7T_OS_CLIENT_ID")
+        self.OS_CLIENT_SECRET        = os.environ.get("F7T_OS_CLIENT_SECRET")
+        self.OS_DISCOVERY_ENDPOINT   = os.environ.get("F7T_OS_DISCOVERY_ENDPOINT")
+
+        self.OS_AUTH_URL= "https://pollux.cscs.ch:13000/v3"
+        self.OS_IDENTITY_PROVIDER= "cscskc"
+        self.OS_PROTOCOL= "openid"
+        self.OS_INTERFACE= "public"
+        self.OS_PROJECT_ID= "***REMOVED***"
+        self.OS_CLIENT_ID = 'pollux-prod'
+        self.OS_CLIENT_SECRET = '***REMOVED***'
+        self.OS_DISCOVERY_ENDPOINT ='https://auth.cscs.ch/auth/realms/cscs/.well-known/openid-configuration'
+        
+
+    # returns a valid token if username & password are valid keystone credentials
+    def authenticate(self,username,password):
+
+        try:
+
+            auth = V3OidcPassword(auth_url=self.OS_AUTH_URL, identity_provider=self.OS_IDENTITY_PROVIDER, protocol=self.OS_PROTOCOL,
+                                client_id=self.OS_CLIENT_ID, client_secret=self.OS_CLIENT_SECRET, discovery_endpoint=self.OS_DISCOVERY_ENDPOINT, 
+                                username=username, password=password)
+
+
+
+            sess = keystonesession.Session(auth=auth)
+            try:
+
+                log.info(sess.get_token())
+            except AttributeError as e:
+                log.info(e)
+                log.info(e.args)
+
+
+            auth = v3.token.Token(auth_url=self.OS_AUTH_URL, token=sess.get_token(), project_id=self.OS_PROJECT_ID)
+
+            sess = keystonesession.Session(auth=auth)
+
+            OS_TOKEN = sess.get_token()
+
+            return {"error":0,"OS_TOKEN":OS_TOKEN}
+
+        except keystoneexception.http.BadRequest as e:
+            log.error(e)
+            log.error(e.message)
+            log.error(e.details)
+            return {"error":1,"msg":e.message}
+
+
+        except Exception as e:
+
+            log.error(type(e))
+            return {"error":1,"msg":e}
+
+
+    # Checks if token is valid directly with keystone API
+    def is_token_valid(self,token):
+
+        url = f"{self.OS_AUTH_URL}/auth/tokens"
+
+        headers = {"X-Auth-Token":token,
+                "X-Subject-Token":token}
+
+        try:
+
+            r = requests.get(url=url,headers=headers)
+
+            if r.status_code == 200:
+                logging.info("Valid token")
+                return True
+
+            logging.warning("Invalid token")
+
+            return False
+
+        except requests.exceptions.RequestException as re:
+            logging.error(re)
+            logging.error("Invalid token request")
+            return False

--- a/src/storage/keystoneoidc.py
+++ b/src/storage/keystoneoidc.py
@@ -30,16 +30,6 @@ class KeystoneOIDC(Keystone):
         self.OS_CLIENT_SECRET        = os.environ.get("F7T_OS_CLIENT_SECRET")
         self.OS_DISCOVERY_ENDPOINT   = os.environ.get("F7T_OS_DISCOVERY_ENDPOINT")
 
-        self.OS_AUTH_URL= "https://pollux.cscs.ch:13000/v3"
-        self.OS_IDENTITY_PROVIDER= "cscskc"
-        self.OS_PROTOCOL= "openid"
-        self.OS_INTERFACE= "public"
-        self.OS_PROJECT_ID= "***REMOVED***"
-        self.OS_CLIENT_ID = 'pollux-prod'
-        self.OS_CLIENT_SECRET = '***REMOVED***'
-        self.OS_DISCOVERY_ENDPOINT ='https://auth.cscs.ch/auth/realms/cscs/.well-known/openid-configuration'
-        
-
     # returns a valid token if username & password are valid keystone credentials
     def authenticate(self,username,password):
 

--- a/src/storage/keystonesaml.py
+++ b/src/storage/keystonesaml.py
@@ -1,0 +1,94 @@
+#
+#  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
+#
+#  Please, refer to the LICENSE file in the root directory.
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+from keystoneauth1.identity import v3
+from keystoneauth1 import session as keystonesession
+from keystoneauth1 import exceptions as keystoneexception
+from keystoneauth1.extras._saml2 import V3Saml2Password
+
+import logging
+import requests
+import os
+from keystone import Keystone
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+class KeystoneSAML(Keystone):
+
+    def __init__(self):
+        self.OS_AUTH_URL             = os.environ.get("F7T_OS_AUTH_URL")
+        self.OS_IDENTITY_PROVIDER    = os.environ.get("F7T_OS_IDENTITY_PROVIDER")
+        self.OS_IDENTITY_PROVIDER_URL= os.environ.get("F7T_OS_IDENTITY_PROVIDER_URL")
+        self.OS_PROTOCOL             = os.environ.get("F7T_OS_PROTOCOL")
+        self.OS_INTERFACE            = os.environ.get("F7T_OS_INTERFACE")
+        self.OS_PROJECT_ID           = os.environ.get("F7T_OS_PROJECT_ID")
+
+    # returns a valid token if username & password are valid keystone credentials
+    def authenticate(self,username,password):
+
+        try:
+
+            auth = V3Saml2Password(auth_url=self.OS_AUTH_URL, identity_provider=self.OS_IDENTITY_PROVIDER, protocol=self.OS_PROTOCOL,
+                                identity_provider_url=self.OS_IDENTITY_PROVIDER_URL, username=username, password=password)
+
+
+
+            sess = keystonesession.Session(auth=auth)
+            try:
+
+                log.info(sess.get_token())
+            except AttributeError as e:
+                log.info(e)
+                log.info(e.args)
+
+
+            auth = v3.token.Token(auth_url=self.OS_AUTH_URL, token=sess.get_token(), project_id=self.OS_PROJECT_ID)
+
+            sess = keystonesession.Session(auth=auth)
+
+            OS_TOKEN = sess.get_token()
+
+            return {"error":0,"OS_TOKEN":OS_TOKEN}
+
+        except keystoneexception.http.BadRequest as e:
+            log.error(e)
+            log.error(e.message)
+            log.error(e.details)
+            return {"error":1,"msg":e.message}
+
+
+        except Exception as e:
+
+            log.error(type(e))
+            return {"error":1,"msg":e}
+
+
+    # Checks if token is valid directly with keystone API
+    def is_token_valid(self,token):
+
+        url = "{os_auth_url}/auth/tokens".format(os_auth_url=self.OS_AUTH_URL)
+
+        headers = {"X-Auth-Token":token,
+                "X-Subject-Token":token}
+
+        try:
+
+            r = requests.get(url=url,headers=headers)
+
+            if r.status_code == 200:
+                logging.info("Valid token")
+                return True
+
+            logging.warning("Invalid token")
+
+            return False
+
+        except requests.exceptions.RequestException as re:
+            logging.error(re)
+            logging.error("Invalid token request")
+            return False

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -5,8 +5,6 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 from flask import Flask, request, jsonify
-
-import keystone
 import json, tempfile, os
 import urllib
 import datetime


### PR DESCRIPTION
For `dev` this is version `1.7.2-beta1`

- Since SWIFT uses keystone for authentication, and keystone now allows OIDC and (in the near future) SAML, 2 new adapters (`KeystoneOIDC` and `KeystoneSAML`) have been created.

- Environment variable `F7T_OS_KEYSTONE_AUTH` will manage the choice between authentication systems.