### PR TITLE
Restapi 629 fix check for stderr output when storage xfer external download

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.2-beta1
+  version: 1.7.3-beta1
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.2-beta1
+  version: 1.7.3-beta1
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a

--- a/src/common/cscs_api_common.py
+++ b/src/common/cscs_api_common.py
@@ -346,7 +346,6 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
         logging.info(f"stdout: ({stdout_errno}) --> {stdout_errda}")
         logging.info(f"sdtout: ({stdout_errno}) --> {outlines}")
 
-        # TODO: change precedence of error, because in /xfer-external/download this gives error and it s not an error
         if stderr_errno == 0:
             if stderr_errda and not (in_str(stderr_errda,"Could not chdir to home directory") or in_str(stderr_errda,"scancel: Terminating job")):
                 result = {"error": 1, "msg": stderr_errda}
@@ -359,13 +358,17 @@ def exec_remote_command(auth_header, system_name, system_addr, action, file_tran
             else:
                 result = {"error": 0, "msg": outlines}
         elif stderr_errno > 0:
-            result = {"error": stderr_errno, "msg": stderr_errda or stdout_errda}
+            if stderr_errno == 7:
+                result = {"error": 7, "msg": "Failed to connect to staging area server"}
+            else:
+                result = {"error": stderr_errno, "msg": stderr_errda or stdout_errda}
         elif len(stderr_errda) > 0:
             result = {"error": 1, "msg": stderr_errda}
         elif stdout_errno == -2:
             result = {"error": -2, "msg": "Receive ready timeout exceeded"}
         elif stderr_errno == -1:
             result = {"error": -1, "msg": "No exit status was provided by the server"}
+        
 
 
     # first if paramiko exception raise

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -328,7 +328,7 @@ class S3v2(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
+        command = f"curl -s -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
         
         retval["command"] = command
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -401,7 +401,7 @@ class S3v4(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -i -X {httpVerb} {endpoint_url}/{containername}"
+        command = f"curl -s -i -X {httpVerb} {endpoint_url}/{containername}"
 
         for k,v in retval["parameters"]["data"].items():
             command += f" -F '{k}={v}'"

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -245,7 +245,7 @@ class Swift(ObjectStorage):
         signature = hmac.new(secret, hmac_body, sha1).hexdigest()
 
         # added OBJECT_PREFIX as dir_[task_id] in order to become unique the upload instead of user/filename
-        command = f"curl -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
+        command = f"curl -s -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
               f" -X POST " \
               f"-F max_file_size={max_file_size} -F max_file_count={max_file_count} " \
               f"-F expires={expires} -F signature={signature} " \


### PR DESCRIPTION
This fix uses `curl` command (used when uploading a file from the filesystem of the server to the staging area in `xfer-external/download`) with `-s` (silent) mode, therefore the output is not shown in `stderr` buffer (which is considered an error in FirecREST) and catches `errno`. `errno == 7` is triggered when the destination can't be reached, therefore is specified. 
For other errors, they are caught as generic.