### PR TITLE
Fixed check on xfer-external/download when file is uploaded to staging area

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta4
+  version: 1.7.2-beta1
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.1-beta4
+  version: 1.7.2-beta1
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -328,7 +328,7 @@ class S3v2(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -s -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
+        command = f"curl --show-error -s -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
         
         retval["command"] = command
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -401,7 +401,7 @@ class S3v4(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -s -i -X {httpVerb} {endpoint_url}/{containername}"
+        command = f"curl --show-error -s -i -X {httpVerb} {endpoint_url}/{containername}"
 
         for k,v in retval["parameters"]["data"].items():
             command += f" -F '{k}={v}'"

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -245,7 +245,7 @@ class Swift(ObjectStorage):
         signature = hmac.new(secret, hmac_body, sha1).hexdigest()
 
         # added OBJECT_PREFIX as dir_[task_id] in order to become unique the upload instead of user/filename
-        command = f"curl -s -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
+        command = f"curl --show-error -s -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
               f" -X POST " \
               f"-F max_file_size={max_file_size} -F max_file_count={max_file_count} " \
               f"-F expires={expires} -F signature={signature} " \


### PR DESCRIPTION
This fix uses `curl` command (used when uploading a file from the filesystem of the server to the staging area in `xfer-external/download`) with `-s` (silent) mode, therefore the output is not shown in stderr buffer (which is considered an error in FirecREST) and catches errno. `errno == 7` is triggered when the destination can't be reached, therefore is specified.
For other errors, they are caught as generic.