### PR TITLE
publish FirecREST API via redoc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+## from: https://medium.com/hoursofoperation/auto-generate-swagger-docs-to-gitlab-pages-ca040230df3a
+pages:
+  image: node:latest
+  stage: deploy
+  script:
+  - npm install -g redoc-cli
+  - ls -las doc/openapi
+  - redoc-cli bundle -o public/index.html doc/openapi/firecrest-developers-api.yaml
+  - mkdir public/api && cp public/index.html public/api/
+  - ls -lasR public
+  - echo 🎉 URL is https://fgeorgatos.gitlab.io/firecrest/api/
+  artifacts:
+    paths:
+    - public


### PR DESCRIPTION
Hello,

This is just a scaffold PR, on which you might wish to build on.
Example output: https://fgeorgatos.gitlab.io/firecrest/api/ ## scroll down for the interesting bits

fyi. I was motivated to look at it, since I wished to inspect how far FirecREST API has been, today; I hope it's useful to others.
The diff of commits which made this work is visible here: (ask if you need help with the github/gitlab-ci integration)
* https://gitlab.com/fgeorgatos/firecrest/-/compare/master...master-20210409FG-test-redoc-cli