### PR TITLE
Enabling SLURM spank plugin's selection

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.3-beta1
+  version: 1.7.4-beta1
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.3-beta1
+  version: 1.7.4-beta1
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -328,7 +328,7 @@ class S3v2(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -s -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
+        command = f"curl --show-error -s -i -X {httpVerb} '{url}?AWSAccessKeyId={self.user}&Signature={sig}&Expires={expires}' -T {sourcepath}"
         
         retval["command"] = command
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -401,7 +401,7 @@ class S3v4(ObjectStorage):
             "headers": {}
         }
 
-        command = f"curl -s -i -X {httpVerb} {endpoint_url}/{containername}"
+        command = f"curl --show-error -s -i -X {httpVerb} {endpoint_url}/{containername}"
 
         for k,v in retval["parameters"]["data"].items():
             command += f" -F '{k}={v}'"

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -245,7 +245,7 @@ class Swift(ObjectStorage):
         signature = hmac.new(secret, hmac_body, sha1).hexdigest()
 
         # added OBJECT_PREFIX as dir_[task_id] in order to become unique the upload instead of user/filename
-        command = f"curl -s -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
+        command = f"curl --show-error -s -i {swift_url}/{swift_version}/{swift_account}/{containername}/{prefix}/" \
               f" -X POST " \
               f"-F max_file_size={max_file_size} -F max_file_count={max_file_count} " \
               f"-F expires={expires} -F signature={signature} " \


### PR DESCRIPTION
Once merged it'll become version `v1.7.4`

- Includes SLURM spank plugin selection in `compute` microservice API:
  - Added env var `F7T_USE_SPANK_PLUGIN` as a list of boolean values. The position of each value corresponds with the position in `F7T_SYSTEMS_PUBLIC` var. `True` means that the plugin is activated in that system.
  - Added env var `F7T_SPANK_PLUGIN_OPTION` in which the value of the spank plugin is set (by default `--nohome`)
