### PR TITLE
Restapi 631 token validation is not checked properly on poll of unfinished uploads

### DIFF
--- a/src/storage/objectstorage.py
+++ b/src/storage/objectstorage.py
@@ -17,6 +17,14 @@ class ObjectStorage:
     @abstractmethod
     def authenticate(self,user,passwd):
         pass
+    
+    @abstractmethod
+    def is_token_valid(self):
+        pass
+
+    @abstractmethod
+    def renew_token(self):
+        pass
 
     @abstractmethod
     def create_container(self,containername):
@@ -59,6 +67,5 @@ class ObjectStorage:
         pass
 
 
-    def is_token_valid(self):
-        pass
+    
 

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -278,10 +278,15 @@ class S3v2(ObjectStorage):
             logging.error("Error: {}".format(e))
             return False
 
+    # Since S3 is used with signature, no token is needed, 
+    # but this is kept only for consistency with objectstorage class
     def authenticate(self, user, passwd):
         return True
 
     def is_token_valid(self):
+        return True
+
+    def renew_token(self):
         return True
 
     def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size):

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -337,10 +337,15 @@ class S3v4(ObjectStorage):
 
 
 
+    # Since S3 is used with signature, no token is needed, 
+    # but this is kept only for consistency with objectstorage class
     def authenticate(self, user, passwd):
         return True
 
     def is_token_valid(self):
+        return True
+
+    def renew_token(self):
         return True
 
     def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size):

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -316,11 +316,10 @@ def download_task(auth_header,system_name, system_addr,sourcePath,task_id):
     global staging
 
     # check if staging area token is valid
-    if not staging.is_token_valid():
-        if not staging.authenticate():
-            msg = "Staging area auth error"
-            update_task(task_id, auth_header, async_task.ERROR, msg)
-            return
+    if not staging.renew_token():
+        msg = "Staging area auth error"
+        update_task(task_id, auth_header, async_task.ERROR, msg)
+        return
 
     # create container if it doesn't exists:
     container_name = get_username(auth_header)
@@ -505,14 +504,13 @@ def upload_task(auth_header,system_name, system_addr,targetPath,sourcePath,task_
     update_task(task_id, auth_header, async_task.ST_URL_ASK, data, is_json=True)
 
     # check if staging token is valid
-    if not staging.is_token_valid():
-        if not staging.authenticate():
-            data = uploaded_files[task_id]
-            msg = "Staging Area auth error, try again later"
-            data["msg"] = msg
-            data["status"] = async_task.ERROR
-            update_task(task_id, auth_header, async_task.ERROR, data, is_json=True)
-            return
+    if not staging.renew_token():
+        data = uploaded_files[task_id]
+        msg = "Staging Area auth error, try again later"
+        data["msg"] = msg
+        data["status"] = async_task.ERROR
+        update_task(task_id, auth_header, async_task.ERROR, data, is_json=True)
+        return
 
 
     # create or return container


### PR DESCRIPTION
- Created method `renew_token()` to validate and request (if needed) a new keystone token for SWIFT object storage.
- Method is replicated (but not used) in S3 classes, since S3 abstractions don't use token, but pre-signed URLs to the API.
- `Swift` methods now check for token expiration before API request is executed.