### PR TITLE
Restapi 649 separate public and private url for object storage

### DIFF
--- a/ci/pre-prod/Jenkinsfile
+++ b/ci/pre-prod/Jenkinsfile
@@ -171,6 +171,11 @@ node {
                 towerLogLevel: 'full',
                 removeColor: false,
                 verbose: true,
+                extraVars: """
+                docker_registry_host: 148.187.97.229:5000
+                build_tag: $shortCommit
+                commit_id: $longCommit
+                """,
                 async: false,
                 throwExceptionWhenFail: false
             )

--- a/ci/pre-prod/remove_demo_containers.yml
+++ b/ci/pre-prod/remove_demo_containers.yml
@@ -7,7 +7,7 @@
 
 
 ---
-- name: Remove firecrest containers
+- name: Remove FirecREST containers
   gather_facts: No
   hosts: all
   vars:
@@ -50,6 +50,20 @@
         name: demo_default
         state: absent
         force: yes
+
+    - name: Delete FirecREST images
+      docker_image:
+        name: "{{ docker_registry_host }}/{{ item }}:{{ build_tag }}"
+        state: absent
+      with_items:
+        - tasks
+        - certificator
+        - compute
+        - reservations
+        - status
+        - storage
+        - utilities
+      
 
     - name: Clean firecrest deploy folder
       file:

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -87,7 +87,8 @@ services:
     env_file:
       - ./common/common.env
     environment:
-      F7T_S3_URL: http://192.168.220.19:9000
+      F7T_S3_PRIVATE_URL: http://192.168.220.19:9000
+      F7T_S3_PUBLIC_URL: http://127.0.0.1:9000
       F7T_S3_ACCESS_KEY: storage_access_key
       F7T_S3_SECRET_KEY: storage_secret_key
       F7T_STORAGE_POLLING_INTERVAL: 60 
@@ -270,15 +271,14 @@ services:
       - ./ssl:/ssl
 
   openapi:
-    # image: swaggerapi/swagger-ui:v3.22.0
-    build:
-      context: ../../
-      dockerfile: ./deploy/docker/openapi/Dockerfile
+    image: swaggerapi/swagger-ui:v3.22.0
     container_name: openapi
     ports:
       - "9090:8080"
     environment:
-      SWAGGER_JSON: /tmp/openapi.yaml
+      SWAGGER_JSON: /tmp/firecrest-developers-api.yaml
+    volumes:
+      - ../../doc/openapi/:/tmp/
 
   jaeger:
     image: jaegertracing/all-in-one:1.24

--- a/deploy/docker/openapi/Dockerfile
+++ b/deploy/docker/openapi/Dockerfile
@@ -1,9 +1,0 @@
-##
-##  Copyright (c) 2019-2021, ETH Zurich. All rights reserved.
-##
-##  Please, refer to the LICENSE file in the root directory.
-##  SPDX-License-Identifier: BSD-3-Clause
-##
-FROM swaggerapi/swagger-ui:v3.22.0
-
-COPY doc/openapi/firecrest-developers-api.yaml /tmp/openapi.yaml

--- a/deploy/test-build/docker-compose.yml
+++ b/deploy/test-build/docker-compose.yml
@@ -167,16 +167,16 @@ services:
       - ./ssl:/ssl
 
   openapi:
-    build:
-      context: ../../
-      dockerfile: ./deploy/docker/openapi/Dockerfile
+    image: swaggerapi/swagger-ui:v3.22.0
     networks:
       - backend
       - frontend
     ports:
       - "9090:8080"
     environment:
-      SWAGGER_JSON: /tmp/openapi.yaml
+      SWAGGER_JSON: /tmp/firecrest-developers-api.yaml
+    volumes:
+      - ../../doc/openapi/:/tmp/
 
 # For now all containers are attached to both networks.
 # Next step is to split microservices to the

--- a/deploy/test-build/environment/storage.env
+++ b/deploy/test-build/environment/storage.env
@@ -1,6 +1,7 @@
 # OBJECT STORAGE DATA
 # for SWIFT
-F7T_SWIFT_URL=
+F7T_SWIFT_PRIVATE_URL=
+F7T_SWIFT_PUBLIC_URL=
 F7T_SWIFT_API_VERSION=
 F7T_SWIFT_ACCOUNT=
 F7T_SWIFT_USER=
@@ -9,7 +10,8 @@ F7T_SWIFT_PASS=
 F7T_SECRET_KEY=
 
 # for S3
-F7T_S3_URL=http://minio_test_build:9000
+F7T_S3_PRIVATE_URL=http://minio_test_build:9000
+F7T_S3_PUBLIC_URL=http://minio_test_build:9000
 F7T_S3_ACCESS_KEY=storage_access_key
 F7T_S3_SECRET_KEY=storage_secret_key
 

--- a/src/storage/objectstorage.py
+++ b/src/storage/objectstorage.py
@@ -51,7 +51,7 @@ class ObjectStorage:
         pass
 
     @abstractmethod
-    def create_temp_url(self,containername,prefix,objectname,ttl):
+    def create_temp_url(self,containername,prefix,objectname,ttl,internal):
         pass
 
     @abstractmethod
@@ -59,7 +59,7 @@ class ObjectStorage:
         pass
 
     @abstractmethod
-    def create_upload_form(self,sourcepath,containername,prefix,ttl,max_file_size):
+    def create_upload_form(self,sourcepath,containername,prefix,ttl,max_file_size,internal):
         pass
 
     @abstractmethod

--- a/src/storage/s3v2OS.py
+++ b/src/storage/s3v2OS.py
@@ -21,10 +21,11 @@ logger.setLevel(logging.INFO)
 
 class S3v2(ObjectStorage):
 
-    def __init__(self, url, user, passwd):
+    def __init__(self, priv_url, publ_url, user, passwd):
         self.user = user
         self.passwd = passwd
-        self.url = url
+        self.priv_url = priv_url
+        self.publ_url = publ_url
 
     def get_object_storage(self):
         return "Amazon S3 - Signature V2"
@@ -36,10 +37,9 @@ class S3v2(ObjectStorage):
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}".format(containername=containername)
+        canonicalizedResource = f"/{containername}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
@@ -51,11 +51,9 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}/{containername}?AWSAccessKeyId={awsAccessKeyId}&Signature={signature}&Expires={expires}".format(
-            url=self.url, containername=containername,
-            awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
+        url = f"{self.priv_url}/{containername}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
 
-        logging.info("Creating bucket {}".format(containername))
+        logging.info(f"Creating container '{containername}'")
 
         try:
             resp = requests.put(url)
@@ -64,7 +62,7 @@ class S3v2(ObjectStorage):
                 return 0
             return -1
         except Exception as e:
-            logging.error("Error: {}".format(e))
+            logging.error(f"Error creating container: {e}")
             return -1
 
     def is_container_created(self, containername):
@@ -74,10 +72,9 @@ class S3v2(ObjectStorage):
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}".format(containername=containername)
+        canonicalizedResource = f"/{containername}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
@@ -89,11 +86,10 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}/{containername}?AWSAccessKeyId={awsAccessKeyId}&Expires={expires}&Signature={signature}".format(
-            url=self.url, containername=containername, awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
-
-        logging.info("Checking for container {}".format(containername))
-        logging.info("URL: {}".format(url))
+        url = f"{self.priv_url}/{containername}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
+        
+        logging.info(f"Checking for container {containername}")
+        logging.info(f"URL: {url}")
         try:
             resp = requests.head(url)
 
@@ -102,8 +98,8 @@ class S3v2(ObjectStorage):
             return resp.ok
 
         except Exception as e:
-            logging.error("Error: {}".format(e))
-            logging.error("Error: {}".format(type(e)))
+            logging.error(f"Error checking container: {e}")
+            logging.error(f"Error type: {type(e)}")
             return False
 
     def get_users(self):
@@ -111,7 +107,7 @@ class S3v2(ObjectStorage):
         expires = 120 + int(time.time())
 
 
-        string_to_sign = "GET\n\n\n%s\n/" % (expires)
+        string_to_sign = f"GET\n\n\n{expires}\n/"
 
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (string_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
@@ -122,10 +118,9 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Python3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}?AWSAccessKeyId={awsAccessKeyId}&Expires={expires}&Signature={signature}".format(
-            url=self.url, awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
-
-        logging.info("URL: {}".format(url))
+        url = f"{self.priv_url}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
+        
+        logging.info(f"Get Users URL: {url}")
         try:
             resp = requests.get(url)
 
@@ -165,8 +160,8 @@ class S3v2(ObjectStorage):
             return None
 
         except Exception as e:
-            logging.error("Error: {}".format(e))
-            logging.error("Error: {}".format(type(e)))
+            logging.error(f"Error Get Users: {e}")
+            logging.error(f"Error type: {type(e)}")
             return None
 
     def list_objects(self,containername,prefix=None):
@@ -179,10 +174,7 @@ class S3v2(ObjectStorage):
         canonicalizedAmzHeaders = ""
         canonicalizedResource = f"/{containername}/"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
-
-        # string_to_sign = f"GET\n\n\n{str(expires)}\n/"
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
@@ -190,13 +182,12 @@ class S3v2(ObjectStorage):
 
         sig = base64.b64encode(hmac.new(_passwd, string_to_sign, hashlib.sha1).digest())
 
-        # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
+        # signature will be Bytes type in Python3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}/{containername}/?AWSAccessKeyId={awsAccessKeyId}&Expires={expires}&Signature={signature}".format(
-            containername=containername,url=self.url, awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
+        url = f"{self.priv_url}/{containername}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
 
-        logging.info("URL: {}".format(url))
+        logging.info(f"List objects URL: {url}")
         try:
             resp = requests.get(url)
 
@@ -235,8 +226,8 @@ class S3v2(ObjectStorage):
             return None
 
         except Exception as e:
-            logging.error("Error: {}".format(e))
-            logging.error("Error: {}".format(type(e)))
+            logging.error(f"Get Objects Error: {e}")
+            logging.error(f"Error type: {type(e)}")
             return None
 
     def is_object_created(self, containername, prefix, objectname):
@@ -246,14 +237,10 @@ class S3v2(ObjectStorage):
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}/{prefix}/{objectname}".format(
-            containername=containername, prefix=prefix, objectname=objectname)
+        canonicalizedResource = f"/{containername}/{prefix}/{objectname}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
-
-
-
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
+        
         # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
@@ -264,9 +251,7 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}/{containername}/{prefix}/{objectname}?AWSAccessKeyId={awsAccessKeyId}&Signature={signature}&Expires={expires}".format(
-            url=self.url, containername=containername, prefix=prefix, objectname=objectname,
-            awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
+        url = f"{self.priv_url}/{containername}/{prefix}/{objectname}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
 
         try:
             resp = requests.head(url)
@@ -275,7 +260,7 @@ class S3v2(ObjectStorage):
                 return True
             return False
         except Exception as e:
-            logging.error("Error: {}".format(e))
+            logging.error(f"Error checking object: {e}")
             return False
 
     # Since S3 is used with signature, no token is needed, 
@@ -289,7 +274,9 @@ class S3v2(ObjectStorage):
     def renew_token(self):
         return True
 
-    def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size):
+    ## returns a Temporary Form URL for uploading without client and tokens
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size,internal=True):
 
         objectname = sourcepath.split("/")[-1]
 
@@ -298,11 +285,9 @@ class S3v2(ObjectStorage):
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}/{prefix}/{objectname}".format(
-            containername=containername, prefix=prefix, objectname=objectname)
+        canonicalizedResource = f"/{containername}/{prefix}/{objectname}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
@@ -313,8 +298,10 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
         
-        url = "{url}/{containername}/{prefix}/{objectname}".format(
-            url=self.url, containername=containername, prefix=prefix, objectname=objectname)
+        if internal:
+            url = f"{self.priv_url}/{containername}/{prefix}/{objectname}"
+        else:
+            url = f"{self.publ_url}/{containername}/{prefix}/{objectname}"
 
         retval = {}
 
@@ -339,20 +326,18 @@ class S3v2(ObjectStorage):
 
         return retval
 
-    def create_temp_url(self, containername, prefix, objectname, ttl):
+    ## returns a Temporary URL for downloading without client and tokens
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_temp_url(self, containername, prefix, objectname, ttl, internal=True):
 
         expires = ttl + int(time.time())
         httpVerb = "GET"
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}/{prefix}/{objectname}".format(
-            containername=containername, prefix=prefix, objectname=objectname)
+        canonicalizedResource = f"/{containername}/{prefix}/{objectname}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
-
-        # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
@@ -363,9 +348,10 @@ class S3v2(ObjectStorage):
         # signature will be Bytes type in Pytho3, so it needs to be decoded to str again
         sig = sig.decode('latin-1')
 
-        url = "{url}/{containername}/{prefix}/{objectname}?AWSAccessKeyId={awsAccessKeyId}&Signature={signature}&Expires={expires}".format(
-            url=self.url, containername=containername, prefix=prefix, objectname=objectname,
-            awsAccessKeyId=self.user, signature=urllib.parse.quote(sig), expires=expires)
+        if internal:
+            url = f"{self.priv_url}/{containername}/{prefix}/{objectname}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
+        else:
+            url = f"{self.publ_url}/{containername}/{prefix}/{objectname}?AWSAccessKeyId={self.user}&Signature={urllib.parse.quote(sig)}&Expires={expires}"
 
         return url
 
@@ -383,30 +369,23 @@ class S3v2(ObjectStorage):
         contentMD5 = ""
         contentType = ""
         canonicalizedAmzHeaders = ""
-        canonicalizedResource = "/{containername}/{prefix}/{objectname}".format(
-            containername=containername,prefix=prefix,objectname=objectname)
+        canonicalizedResource = f"/{containername}/{prefix}/{objectname}"
 
-        string_to_sign = httpVerb + "\n" + contentMD5 + "\n" + contentType + "\n" + \
-                         str(expires) + "\n" + canonicalizedAmzHeaders + canonicalizedResource
-
-
-        # sig = base64.b64encode(hmac.new(self.passwd, string_to_sign, hashlib.sha1).digest())
+        string_to_sign = f"{httpVerb}\n{contentMD5}\n{contentType}\n{str(expires)}\n{canonicalizedAmzHeaders}{canonicalizedResource}"
 
         # to be used in hmac.new(key,msg,digestmode), the strings key (passwd) and msg (strin_to_sign) need to be byte type
         string_to_sign = string_to_sign.encode('latin-1')
         _passwd = bytes(self.passwd, 'latin1')
 
-        sig = base64.b64encode(hmac.new(_passwd, string_to_sign, hashlib.sha1).digest())
+        _sig = base64.b64encode(hmac.new(_passwd, string_to_sign, hashlib.sha1).digest())
 
         # signature will be Bytes type in Python3, so it needs to be decoded to str again
-        sig = sig.decode('latin-1')
+        signature = _sig.decode('latin-1')
 
-        url = "{url}/{containername}/{prefix}/{objectname}&AWSAccessKeyId={awsAccessKeyId}&Signature={signature}&Expires={expires}".format(
-            url=self.url, containername=containername, prefix=prefix,objectname=objectname,
-            awsAccessKeyId=self.user, signature=sig, expires=expires)
+        url = f"{self.priv_url}/{containername}/{prefix}/{objectname}&AWSAccessKeyId={self.user}&Signature={signature}&Expires={expires}"
 
-        print("Deleting {}/{}/{}".format(containername,prefix,objectname))
-        print("URL: {}".format(url))
+        logging.info(f"Deleting Object {containername}/{prefix}/{objectname}")
+        logging.info(f"URL: {url}")
 
         try:
             resp = requests.delete(url)
@@ -417,12 +396,12 @@ class S3v2(ObjectStorage):
 
                 return 0
             # TODO: not working for some reason
+            logging.error(f"Object couldn't be deleted {url}")
             logging.error(resp.content)
-            logging.error("Object couldn't be deleted "+url)
             return -1
         except Exception as e:
-            logging.info(e)
-            logging.error("Object couldn't be deleted "+url)
+            logging.error(f"Object couldn't be deleted {url}")
+            logging.error(e)
             return -1
 
 

--- a/src/storage/s3v4OS.py
+++ b/src/storage/s3v4OS.py
@@ -22,10 +22,11 @@ import json
 
 class S3v4(ObjectStorage):
 
-    def __init__(self, url, user, passwd):
+    def __init__(self, priv_url, publ_url, user, passwd):
         self.user = user
         self.passwd = passwd
-        self.url = url
+        self.priv_url = priv_url
+        self.publ_url = publ_url
 
     def get_object_storage(self):
         return "Amazon S3 - Signature v4"
@@ -48,8 +49,8 @@ class S3v4(ObjectStorage):
         aws_request = "aws4_request"
         aws_access_key_id = self.user
         aws_secret_access_key = self.passwd
-        endpoint_url = self.url
-        host = self.url.split("/")[-1]
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -57,28 +58,23 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername
-
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
-
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
+        canonical_uri = f"/{containername}"
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
 
         # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(ttl)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(ttl)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
+        payload_hash = "UNSIGNED-PAYLOAD"
 
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
 
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -86,30 +82,27 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
-
-        logging.info("Deleting {}".format(containername))
-        logging.info("URL: {}".format(url))
+        logging.info(f"Creating container '{containername}'")
+        logging.info(f"URL: {url}")
 
         try:
             resp = requests.put(url)
-            print(resp.status_code)
-            print(resp.text)
-
+            
             if resp.ok:
                 logging.info("Container created succesfully")
 
                 return 0
             logging.error("Container couldn't be created")
+            logging.error(resp.content)
             return -1
         except Exception as e:
-            logging.error(e)
+            
             logging.error("Container couldn't be created")
+            logging.error(e)
             return -1
 
 
@@ -119,10 +112,10 @@ class S3v4(ObjectStorage):
         algorithm = 'AWS4-HMAC-SHA256'
         service = "s3"
         aws_request = "aws4_request"
-        aws_access_key_id = self.user  #
-        aws_secret_access_key = self.passwd  # 
-        endpoint_url = self.url  # 
-        host = self.url.split("/")[-1]  # 
+        aws_access_key_id = self.user
+        aws_secret_access_key = self.passwd
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -130,28 +123,21 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername
+        canonical_uri = f"/{containername}"
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
+        
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(120)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+        payload_hash = "UNSIGNED-PAYLOAD" 
 
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(120)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -159,19 +145,19 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
-
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
         try:
-            response = requests.head(url)
-            if response.ok:
+            resp = requests.head(url)
+            if resp.ok:
                 return True
+            logging.error("Container couldn't be checked")
+            logging.error(resp.content)
             return False
         except requests.exceptions.ConnectionError as ce:
+            logging.error("Container couldn't be checked")
             logging.error(ce.strerror)
             return False
 
@@ -180,61 +166,47 @@ class S3v4(ObjectStorage):
         algorithm = 'AWS4-HMAC-SHA256'
         service = "s3"
         aws_request = "aws4_request"
-        aws_access_key_id = self.user  #
-        aws_secret_access_key = self.passwd  # 
-        endpoint_url = self.url  # 
-        host = self.url.split("/")[-1]  # 
+        aws_access_key_id = self.user
+        aws_secret_access_key = self.passwd
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]
         region = "us-east-1"
 
         # Create a date for headers and the credential string
         t = datetime.utcnow()
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
+        
+        canonical_uri = "/"
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
+        
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(120)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        canonical_uri = "/" 
+        payload_hash = "UNSIGNED-PAYLOAD"
 
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
-
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(120)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
-
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
+        
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
 
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
-
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
         try:
             resp = requests.get(url)
-
-            # logging.info(response.text)
-
             
             if resp.ok:
-                # logging.info(resp.content)
                 root = ElementTree.fromstring(resp.content)
 
                 for _, nsvalue in ElementTree.iterparse(BytesIO(resp.content), events=['start-ns']):
@@ -269,8 +241,8 @@ class S3v4(ObjectStorage):
             return None
 
         except Exception as e:
-            logging.error("Error: {}".format(e))
-            logging.error("Error: {}".format(type(e)))
+            logging.error(f"Error getting users: {e}")
+            logging.error(f"Error type: {type(e)}")
             return None
 
     def is_object_created(self, containername, prefix, objectname):
@@ -279,10 +251,10 @@ class S3v4(ObjectStorage):
         algorithm = 'AWS4-HMAC-SHA256'
         service = "s3"
         aws_request = "aws4_request"
-        aws_access_key_id = self.user  # "storage_access_key"
-        aws_secret_access_key = self.passwd  # "storage_secret_key"
-        endpoint_url = self.url  # "http://192.168.220.19:9000"
-        host = self.url.split("/")[-1]  # 192.168.220.19:9000"
+        aws_access_key_id = self.user
+        aws_secret_access_key = self.passwd
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -290,28 +262,21 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        canonical_uri = f"/{containername}/{prefix}/{objectname}"
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
+        
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(120)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+        payload_hash = "UNSIGNED-PAYLOAD" 
 
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(120)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -319,12 +284,9 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        # print(f"Canonical request: \n{canonical_request}")
-        # print(f"String to Sign: \n{string_to_sign}")
-
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
         try:
             response = requests.head(url)
@@ -348,16 +310,19 @@ class S3v4(ObjectStorage):
     def renew_token(self):
         return True
 
-    def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size):
+    ## returns a Temporary Form URL for uploading without client and tokens
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_upload_form(self, sourcepath, containername, prefix, ttl, max_file_size, internal=True):
 
         httpVerb = "POST"
         algorithm = 'AWS4-HMAC-SHA256'
         service = "s3"
         aws_request = "aws4_request"
-        # aws_access_key_id = self.user
         aws_secret_access_key = self.passwd
-        endpoint_url = self.url  # "http://ip[:port]"
-        # host = self.url.split("/")[-1]  # ip[:port["
+        if internal:
+            endpoint_url = self.priv_url
+        else:
+            endpoint_url = self.publ_url
         region = "us-east-1"
         objectname = sourcepath.split("/")[-1]
 
@@ -417,8 +382,9 @@ class S3v4(ObjectStorage):
 
         return retval
         
-
-    def create_temp_url(self, containername, prefix, objectname, ttl):
+    ## returns a Temporary URL for downloading without client and tokens
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_temp_url(self, containername, prefix, objectname, ttl, internal=True):
 
         httpVerb = "GET"
         algorithm = 'AWS4-HMAC-SHA256'
@@ -426,8 +392,12 @@ class S3v4(ObjectStorage):
         aws_request = "aws4_request"
         aws_access_key_id = self.user
         aws_secret_access_key = self.passwd 
-        endpoint_url = self.url 
-        host = self.url.split("/")[-1] 
+        if internal:
+            endpoint_url = self.priv_url
+        else:
+            endpoint_url = self.publ_url
+        
+        host = endpoint_url.split("/")[-1] 
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -435,28 +405,21 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        canonical_uri = f"/{containername}/{prefix}/{objectname}"
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
+        
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(ttl)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+        payload_hash = "UNSIGNED-PAYLOAD" 
 
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(ttl)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -464,9 +427,9 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
         return url
 
@@ -477,8 +440,8 @@ class S3v4(ObjectStorage):
         aws_request = "aws4_request"
         aws_access_key_id = self.user  
         aws_secret_access_key = self.passwd  
-        endpoint_url = self.url  
-        host = self.url.split("/")[-1]  
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]  
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -487,27 +450,21 @@ class S3v4(ObjectStorage):
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
         canonical_uri = f"/{containername}" 
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
 
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+        
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(120)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
+        payload_hash = "UNSIGNED-PAYLOAD" 
 
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(120)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -515,9 +472,9 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
 
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
         try:
             resp = requests.get(url)
@@ -557,8 +514,8 @@ class S3v4(ObjectStorage):
             return None
 
         except Exception as e:
-            logging.error("Error: {}".format(e))
-            logging.error("Error: {}".format(type(e)))
+            logging.error(f"Error listing objects: {e}")
+            logging.error(f"Error type: {type(e)}")
             return None
 
     def _prepare_xml(self,prefix, expiration_date_value):
@@ -595,8 +552,7 @@ class S3v4(ObjectStorage):
         hash256 = hashlib.sha256()
         hash256.update(body)
         sha256sum =  hash256.hexdigest()
-        # sha256sum_decoded = sha256sum.decode()
-
+        
         return body, md5sum_decoded, sha256sum
 
     # For S3v4 delete_at only works at midnight UTC (from http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html)
@@ -611,8 +567,8 @@ class S3v4(ObjectStorage):
         aws_request = "aws4_request"
         aws_access_key_id = self.user
         aws_secret_access_key = self.passwd
-        endpoint_url = self.url
-        host = self.url.split("/")[-1]
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1]
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -626,32 +582,22 @@ class S3v4(ObjectStorage):
         d1 = datetime.strptime(d1_str,"%Y-%m-%d") # convert to datetime        
         d2 = d1 + timedelta(days=1) # add 1 day        
         _delete_at_iso = d2.strftime("%Y-%m-%dT%H:%M:%SZ") # after adding 1 day, reconvert to str
-
         
         [body, content_md5, content_sha256] = self._prepare_xml(prefix, _delete_at_iso)
 
-        canonical_uri = "/" + containername 
-
+        canonical_uri = f"/{containername}"
         canonical_headers = f"content-md5:{content_md5}\nhost:{host}\nx-amz-content-sha256:{content_sha256}\nx-amz-date:{amzdate}"
-        
         signed_headers = "content-md5;host;x-amz-content-sha256;x-amz-date"
-
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-        
-
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
         canonical_querystring = "lifecycle="
-
-        
 
         headers = { "Content-MD5": content_md5, 
                     "Host": host,
                     "X-Amz-Content-Sha256": content_sha256,
                     "X-Amz-Date": amzdate}
 
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n\n' + signed_headers + "\n" + content_sha256
-       
-
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n\n{signed_headers}\n{content_sha256}"
+        
         canonical_request_hash = hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()
 
         string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{canonical_request_hash}"
@@ -663,9 +609,8 @@ class S3v4(ObjectStorage):
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
         headers["Authorization"] = f"AWS4-HMAC-SHA256 Credential={aws_access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
-    
-        url = endpoint_url + canonical_uri +"?"+ canonical_querystring
-       
+
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
         
         try:
             resp = requests.put(url, data=body, headers=headers)
@@ -694,8 +639,8 @@ class S3v4(ObjectStorage):
         aws_request = "aws4_request"
         aws_access_key_id = self.user
         aws_secret_access_key = self.passwd 
-        endpoint_url = self.url 
-        host = self.url.split("/")[-1] 
+        endpoint_url = self.priv_url
+        host = endpoint_url.split("/")[-1] 
         region = "us-east-1"
 
         # Create a date for headers and the credential string
@@ -703,28 +648,23 @@ class S3v4(ObjectStorage):
         amzdate = t.strftime('%Y%m%dT%H%M%SZ')
         datestamp = t.strftime('%Y%m%d')  # Date w/o time, used in credential scope
 
-        canonical_uri = "/" + containername + "/" + prefix + "/" + objectname
+        canonical_uri = f"/{containername}/{prefix}/{objectname}"
+
+        canonical_headers = f"host:{host}\n"
+        signed_headers = "host"
+        credential_scope = f"{datestamp}/{region}/{service}/{aws_request}"
+
         
-        canonical_headers = 'host:' + host + "\n"  # + "x-amz-date:"+ amzdate + "\n"
+        canonical_querystring = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        canonical_querystring += f"&X-Amz-Credential={urllib.parse.quote_plus(f'{aws_access_key_id}/{credential_scope}')}"
+        canonical_querystring += f"&X-Amz-Date={amzdate}"
+        canonical_querystring += f"&X-Amz-Expires={str(ttl)}"
+        canonical_querystring += f"&X-Amz-SignedHeaders={signed_headers}"
 
-        signed_headers = "host"  # "host;x-amz-content-sha256;x-amz-date"
+        payload_hash = "UNSIGNED-PAYLOAD" 
 
-        credential_scope = datestamp + '/' + region + '/' + service + '/' + aws_request
-
-        # canonical_querystring = bucket_name+"/"+object_name
-        canonical_querystring = 'X-Amz-Algorithm=AWS4-HMAC-SHA256'
-        canonical_querystring += '&X-Amz-Credential=' + urllib.parse.quote_plus(
-            aws_access_key_id + '/' + credential_scope)
-        canonical_querystring += '&X-Amz-Date=' + amzdate
-        canonical_querystring += '&X-Amz-Expires=' + str(ttl)
-        canonical_querystring += '&X-Amz-SignedHeaders=' + signed_headers
-
-        payload_hash = "UNSIGNED-PAYLOAD"  # ???????? hashlib.sha256(("").encode("utf-8")).hexdigest()
-
-        canonical_request = httpVerb + "\n" + canonical_uri + "\n" + canonical_querystring + "\n" + canonical_headers + '\n' + signed_headers + "\n" + payload_hash
-
-        string_to_sign = algorithm + "\n" + amzdate + "\n" + credential_scope + "\n" + hashlib.sha256(
-            canonical_request.encode("utf-8")).hexdigest()
+        canonical_request = f"{httpVerb}\n{canonical_uri}\n{canonical_querystring}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+        string_to_sign = f"{algorithm}\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode('utf-8')).hexdigest()}"
 
         # Create the signing key
         signing_key = self.getSignatureKey(aws_secret_access_key, datestamp, region, service)
@@ -732,12 +672,12 @@ class S3v4(ObjectStorage):
         # Sign the string_to_sign using the signing_key
         signature = hmac.new(signing_key, (string_to_sign).encode("utf-8"), hashlib.sha256).hexdigest()
 
-        canonical_querystring += '&X-Amz-Signature=' + signature
+        canonical_querystring += f"&X-Amz-Signature={signature}"
         
-        url = endpoint_url + canonical_uri + "?" + canonical_querystring
+        url = f"{endpoint_url}{canonical_uri}?{canonical_querystring}"
 
-        logging.info(f"Deleting {canonical_uri}")
-        logging.info("URL: {}".format(url))
+        logging.info(f"Deleting object {canonical_uri}")
+        logging.info(f"URL: {url}")
 
         try:
             resp = requests.delete(url)
@@ -749,8 +689,8 @@ class S3v4(ObjectStorage):
             logging.error("Object couldn't be deleted")
             return -1
         except Exception as e:
-            logging.error(e)
             logging.error("Object couldn't be deleted")
+            logging.error(e)
             return -1
 
 

--- a/src/storage/storage.py
+++ b/src/storage/storage.py
@@ -394,7 +394,7 @@ def download_task(headers, system_name, system_addr, sourcePath, task_id):
 
     # get Download Temp URL with [seconds] time expiration
     # create temp url for file: valid for STORAGE_TEMPURL_EXP_TIME seconds
-    temp_url = staging.create_temp_url(container_name, object_prefix, object_name, STORAGE_TEMPURL_EXP_TIME)
+    temp_url = staging.create_temp_url(container_name, object_prefix, object_name, STORAGE_TEMPURL_EXP_TIME,internal=False)
 
     # if error raises in temp url creation:
     if temp_url == None:
@@ -555,7 +555,7 @@ def upload_task(headers, system_name, system_addr, targetPath, sourcePath, task_
     object_prefix = task_id
 
     # create temporary upload form
-    resp = staging.create_upload_form(sourcePath, container_name, object_prefix, STORAGE_TEMPURL_EXP_TIME, STORAGE_MAX_FILE_SIZE)
+    resp = staging.create_upload_form(sourcePath, container_name, object_prefix, STORAGE_TEMPURL_EXP_TIME, STORAGE_MAX_FILE_SIZE, internal=False)
     data = uploaded_files[task_id]
 
     # create download URL for later download from Object Storage to filesystem
@@ -928,43 +928,46 @@ def create_staging():
 
     if OBJECT_STORAGE == "swift":
 
-        app.logger.info("Into swift")
+        app.logger.info("Object Storage selected: SWIFT")
 
         from swiftOS import Swift
 
         # Object Storage URL & data:
-        SWIFT_URL = os.environ.get("F7T_SWIFT_URL")
+        SWIFT_PRIVATE_URL = os.environ.get("F7T_SWIFT_PRIVATE_URL")
+        SWIFT_PUBLIC_URL = os.environ.get("F7T_SWIFT_PUBLIC_URL")
         SWIFT_API_VERSION = os.environ.get("F7T_SWIFT_API_VERSION")
         SWIFT_ACCOUNT = os.environ.get("F7T_SWIFT_ACCOUNT")
         SWIFT_USER = os.environ.get("F7T_SWIFT_USER")
         SWIFT_PASS = os.environ.get("F7T_SWIFT_PASS")
 
-        url = "{swift_url}/{swift_api_version}/AUTH_{swift_account}".format(
-            swift_url=SWIFT_URL, swift_api_version=SWIFT_API_VERSION, swift_account=SWIFT_ACCOUNT)
+        priv_url = f"{SWIFT_PRIVATE_URL}/{SWIFT_API_VERSION}/AUTH_{SWIFT_ACCOUNT}"
+        publ_url = f"{SWIFT_PUBLIC_URL}/{SWIFT_API_VERSION}/AUTH_{SWIFT_ACCOUNT}"
 
-        staging = Swift(url=url, user=SWIFT_USER, passwd=SWIFT_PASS, secret=SECRET_KEY)
+        staging = Swift(priv_url=priv_url,publ_url=publ_url, user=SWIFT_USER, passwd=SWIFT_PASS, secret=SECRET_KEY)
 
     elif OBJECT_STORAGE == "s3v2":
-        app.logger.info("Into s3v2")
+        app.logger.info("Object Storage selected: S3v2")
         from s3v2OS import S3v2
 
-        # For S#:
-        S3_URL = os.environ.get("F7T_S3_URL")
-        S3_ACCESS_KEY = os.environ.get("F7T_S3_ACCESS_KEY")
-        S3_SECRET_KEY = os.environ.get("F7T_S3_SECRET_KEY")
+        # For S3:
+        S3_PRIVATE_URL = os.environ.get("F7T_S3_PRIVATE_URL")
+        S3_PUBLIC_URL  = os.environ.get("F7T_S3_PUBLIC_URL")
+        S3_ACCESS_KEY  = os.environ.get("F7T_S3_ACCESS_KEY")
+        S3_SECRET_KEY  = os.environ.get("F7T_S3_SECRET_KEY")
 
-        staging = S3v2(url=S3_URL, user=S3_ACCESS_KEY, passwd=S3_SECRET_KEY)
+        staging = S3v2(priv_url=S3_PRIVATE_URL, publ_url=S3_PUBLIC_URL, user=S3_ACCESS_KEY, passwd=S3_SECRET_KEY)
 
     elif OBJECT_STORAGE == "s3v4":
-        app.logger.info("Into s3v4")
+        app.logger.info("Object Storage selected: S3v4")
         from s3v4OS import S3v4
 
-        # For S#:
-        S3_URL = os.environ.get("F7T_S3_URL")
-        S3_ACCESS_KEY = os.environ.get("F7T_S3_ACCESS_KEY")
-        S3_SECRET_KEY = os.environ.get("F7T_S3_SECRET_KEY")
+        # For S3:
+        S3_PRIVATE_URL = os.environ.get("F7T_S3_PRIVATE_URL")
+        S3_PUBLIC_URL  = os.environ.get("F7T_S3_PUBLIC_URL")
+        S3_ACCESS_KEY  = os.environ.get("F7T_S3_ACCESS_KEY")
+        S3_SECRET_KEY  = os.environ.get("F7T_S3_SECRET_KEY")
 
-        staging = S3v4(url=S3_URL, user=S3_ACCESS_KEY, passwd=S3_SECRET_KEY)
+        staging = S3v4(priv_url=S3_PRIVATE_URL, publ_url=S3_PUBLIC_URL, user=S3_ACCESS_KEY, passwd=S3_SECRET_KEY)
 
     else:
         app.logger.warning("No Object Storage for staging area was set.")
@@ -976,7 +979,7 @@ def get_upload_unfinished_tasks():
     uploaded_files = {}
 
 
-    app.logger.info("Staging Area Used: {}".format(staging.url))
+    app.logger.info("Staging Area Used: {}".format(staging.priv_url))
     app.logger.info("ObjectStorage Technology: {}".format(staging.get_object_storage()))
 
     try:

--- a/src/storage/swiftOS.py
+++ b/src/storage/swiftOS.py
@@ -16,8 +16,9 @@ from hashlib import sha1
 
 class Swift(ObjectStorage):
 
-    def __init__(self,url,user,passwd,secret):
-        self.url = url
+    def __init__(self,priv_url, publ_url,user,passwd,secret):
+        self.priv_url = priv_url
+        self.publ_url = publ_url
         self.auth = None
         self.user = user
         self.passwd = passwd
@@ -81,9 +82,9 @@ class Swift(ObjectStorage):
 
         # add json request query
 
-        query_url = "{url}?format=json".format(url=self.url)
+        query_url = f"{self.priv_url}?format=json"
 
-        logging.info("Storage URL: %s" % (query_url))
+        logging.info(f"Storage URL: {query_url}")
 
         try:
             # check token validation
@@ -125,14 +126,13 @@ class Swift(ObjectStorage):
             return False
 
         header = {"X-Auth-Token": self.auth}
-        url = "{swift_url}/{containername}".format(
-            swift_url=self.url,  containername=containername)
+        url = f"{self.priv_url}/{containername}"
 
-        logging.info("Container URL: " + url)
+        logging.info(f"Container URL: {url}")
 
         ret = requests.get(url, headers=header)
         if ret.status_code == 200:
-            logging.info("container {containername} exists".format(containername=containername))
+            logging.info(f"Container {containername} exists")
             return True
 
         return False
@@ -140,9 +140,9 @@ class Swift(ObjectStorage):
 
     # Create Container which is a User for our means
     def create_container(self,containername):
-        url = "{swift_url}/{container}".format(swift_url=self.url,container=containername)
+        url = f"{self.priv_url}/{containername}"
 
-        logging.info("Container name: %s" % containername)
+        logging.info(f"Creating container '{containername}'")
 
         try:
 
@@ -158,12 +158,12 @@ class Swift(ObjectStorage):
             req = requests.put(url, headers=header)
 
             if not req.ok:
-                logging.error("Couldn't create container {container}".format(container=containername))
-                logging.error("Response: {}".format(req.content))
-                logging.error("Status code: {}".format(req.status_code))
+                logging.error(f"Couldn't create container '{containername}'")
+                logging.error(f"Response: {req.content}")
+                logging.error(f"Status code: {req.status_code}")
                 return -1
 
-            logging.info("Container {} created succesfully".format(containername))
+            logging.info(f"Container {containername} created succesfully")
             return 0
 
 
@@ -177,10 +177,9 @@ class Swift(ObjectStorage):
     # objectname = name of the object
     def is_object_created(self,containername,prefix,objectname):
 
-        object_prefix = "{prefix}/{objectname}".format(prefix=prefix, objectname=objectname)
+        object_prefix = f"{prefix}/{objectname}"
 
-        url = "{swift_url}/{container}/{object}".format(
-            swift_url=self.url, container=containername,object=object_prefix)
+        url = f"{self.priv_url}/{containername}/{object_prefix}"
 
         try:
             # check token validation
@@ -206,19 +205,23 @@ class Swift(ObjectStorage):
             return False
 
     ## returns a Temporary URL for downloading without client and tokens
-    def create_temp_url(self,containername,prefix,objectname,ttl):
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_temp_url(self,containername,prefix,objectname,ttl,internal=True):
 
         # separating the whole url into: API version, SWIFT Account and the prefix (ie: https://object.cscs.ch)
-        separated_url = self.url.split("/")
+        # 
+        if internal:
+            separated_url = self.priv_url.split("/")
+        else:
+            separated_url = self.publ_url.split("/")
+
         swift_url     = "/".join(separated_url[:-2])
         swift_version = separated_url[-2]
         swift_account = separated_url[-1]
 
 
         #Swift needs from version and on to set the path
-        path = "/{swift_version}/{swift_account}/{containername}/{prefix}/{objectname}". \
-            format(swift_version=swift_version, swift_account=swift_account, containername=containername, prefix=prefix,
-                   objectname=objectname)
+        path = f"/{swift_version}/{swift_account}/{containername}/{prefix}/{objectname}"
 
         secret = self.secret  # The secret temporary URL key set on the Swift cluster.
         # To set a key, run 'swift post -m "Temp-URL-Key: <tempurl key>"'
@@ -228,31 +231,33 @@ class Swift(ObjectStorage):
         # expires = int(time() + 600)  # time before form must be submited 600 secs = 10 mins
         expires = int(time() + int(ttl))
 
-        hmac_body = '%s\n%s\n%s' % (method, expires, path)
+        hmac_body = f"{method}\n{expires}\n{path}"
 
         secret = secret.encode('latin-1')
         hmac_body = hmac_body.encode('latin-1')
 
         signature = hmac.new(secret, hmac_body, sha1).hexdigest()
 
-        return "{swift_url}{path}" \
-               "?temp_url_sig={signature}" \
-               "&temp_url_expires={expires}".format(swift_url=swift_url,path=path, signature=signature,
-                                                    expires=expires)
+        return f"{swift_url}{path}?temp_url_sig={signature}&temp_url_expires={expires}"
 
-    def create_upload_form(self,sourcepath,containername,prefix,ttl,max_file_size):
+    ## returns a Temporary Form URL for uploading without client and tokens
+    # internal=True: by default the method asumes that the temp URL will be used in the internal network
+    def create_upload_form(self,sourcepath,containername,prefix,ttl,max_file_size,internal=True):
 
 
         # separating the whole url into: API version, SWIFT Account and the prefix (ie: https://object.cscs.ch)
-        separated_url = self.url.split("/")
+        if internal:
+            separated_url = self.priv_url.split("/")
+        else:
+            separated_url = self.publ_url.split("/")
+
         swift_url = "/".join(separated_url[:-2])
         swift_version = separated_url[-2]
         swift_account = separated_url[-1]
 
 
         # Swift needs from version and on to set the path
-        path = "/{swift_version}/{swift_account}/{containername}/{prefix}/". \
-            format(swift_version=swift_version, swift_account=swift_account, containername=containername, prefix=prefix)
+        path = f"/{swift_version}/{swift_account}/{containername}/{prefix}/"
 
 
         # URL redirect after compeleting upload
@@ -267,8 +272,7 @@ class Swift(ObjectStorage):
         secret = self.secret  # The secret temporary URL key set on the Swift cluster.
         # To set a key, run 'swift post -m "Temp-URL-Key: <tempurl key>"'
 
-        hmac_body = '%s\n%s\n%s\n%s\n%s' % (path, redirect,
-                                            max_file_size, max_file_count, expires)
+        hmac_body = f"{path}\n{redirect}\n{max_file_size}\n{max_file_count}\n{expires}"
 
         secret = secret.encode("latin-1")
         hmac_body = hmac_body.encode("latin-1")
@@ -310,7 +314,7 @@ class Swift(ObjectStorage):
     def list_objects(self,containername,prefix=None):
         # object_prefix = "{prefix}/{objectname}".format(prefix=prefix, objectname=objectname)
 
-        url = f"{self.url}/{containername}"
+        url = f"{self.priv_url}/{containername}"
         
         try:
             # check token validation
@@ -349,7 +353,7 @@ class Swift(ObjectStorage):
     # sets time to live (TTL) for an object in SWIFT
     def delete_object_after(self,containername,prefix,objectname,ttl):
 
-        swift_account_url = f"{self.url}/{containername}/{prefix}/{objectname}"
+        swift_account_url = f"{self.priv_url}/{containername}/{prefix}/{objectname}"
         # check token validation
         if not self.renew_token():
             logging.error("Keystone token couldn't be renewed")
@@ -378,7 +382,7 @@ class Swift(ObjectStorage):
 
     def delete_object(self,containername,prefix,objectname):
 
-        swift_account_url = f"{self.url}/{containername}/{prefix}"
+        swift_account_url = f"{self.priv_url}/{containername}/{prefix}"
         # check token validation
         if not self.renew_token():
             logging.error("Keystone token couldn't be renewed")


### PR DESCRIPTION
In this PR:

- Separate private and public URL/IP for object storage
  - use of `internal` flag in some methods that expose the URL to clients
  - some reformate of `storage` classes 
- `openapi` Dockerfile is removed and the container is created directly from `swagger` image
- In the CI/CD pipeline for `dev` branch, code is added for removing images in test machine after test are completed