### PR TITLE
Added 'account' optional parameter to POST /compute endpoints

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.5-beta1
+  version: 1.8.0-beta1
   title: FirecREST Developers API
   description: >
     This API specification is intended for FirecREST developers only. There're some endpoints that are not available in the public version for client developers.

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -987,6 +987,9 @@ paths:
                   type: string
                   format: binary
                   description: SBATCH script file to be submitted to SLURM
+                account:
+                  type: string
+                  description:Name of the account associated to the user in the scheduler. If not set, the one incuded in the sbatch file is taken.
               required:
                 - file
       responses:
@@ -1048,6 +1051,9 @@ paths:
                 targetPath:
                   type: string
                   description: path to the SBATCH script file stored in {X-Machine-Name} machine to be submitted to SLURM
+                account:
+                  type: string
+                  description: Name of the account associated to the user in the scheduler. If not set, the one incuded in the sbatch file is taken.
               required:
                 - targetPath
       responses:
@@ -1317,7 +1323,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1401,7 +1407,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1485,7 +1491,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1566,7 +1572,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - targetPath

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -999,6 +999,9 @@ paths:
                   type: string
                   format: binary
                   description: SBATCH script file to be submitted to SLURM
+                account:
+                  type: string
+                  description:Name of the account associated to the user in the scheduler. If not set, the one incuded in the sbatch file is taken.
               required:
                 - file
       responses:
@@ -1060,6 +1063,9 @@ paths:
                 targetPath:
                   type: string
                   description: path to the SBATCH script file stored in {X-Machine-Name} machine to be submitted to SLURM
+                account:
+                  type: string
+                  description: Name of the account associated to the user in the scheduler. If not set, the one incuded in the sbatch file is taken.
               required:
                 - targetPath
       responses:
@@ -1292,7 +1298,7 @@ paths:
       summary: rsync
       description: >-
         Data transfer between internal CSCS file systems. To transfer files and
-        folders from `/project` or `/store` to the `/scratch` file systems for
+        folders from `/users`, `/project` or `/store` to the `/scratch` file systems for
         stage-in or stage-out jobs. Reference:
         https://user.cscs.ch/storage/transfer/internal/
       tags:
@@ -1329,7 +1335,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1375,7 +1381,7 @@ paths:
       summary: move (rename) files
       description: >-
         'Move files between internal CSCS file systems. Rename sourcePath to
-        targetPath, or move sourcePath to targetPath /project or /store
+        targetPath, or move sourcePath to targetPath /users, /project or /store
         to the /scratch file systems. Possible to stage-out jobs providing the
         SLURM Id of a production job. Reference:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
@@ -1413,7 +1419,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1459,7 +1465,7 @@ paths:
       summary: copy files and directories
       description: >-
         'Copy files and directories between internal CSCS file systems. Copy
-        sourcePath to targetPath /project or /store to the /scratch file
+        sourcePath to targetPath /users, /project or /store to the /scratch file
         systems. Possible to stage-out jobs providing the SLURM Id of a
         production job. Reference:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
@@ -1497,7 +1503,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - sourcePath
@@ -1543,7 +1549,7 @@ paths:
       summary: remove files or directories
       description: >-
         'Remove files or directories in the internal CSCS file systems, with
-        options rm -rf. With targetPath pointing to file system
+        options rm -rf. With targetPath pointing to file system /users,
         /project, /store, or /scratch. Possible to stage-out jobs providing the
         SLURM Id of a production job. Reference:
         https://user.cscs.ch/storage/data_transfer/internal_transfer/'
@@ -1578,7 +1584,7 @@ paths:
                   default: null
                 account:
                   type: string
-                  description: Name of the bank account to be used in SLURM. If not set, system default is taken.
+                  description: Name of the account associated to the user in the scheduler. If not set, system default is taken.
                   default: null
               required:
                 - targetPath

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -9,7 +9,7 @@ servers:
   - url: 'http://FIRECREST_URL'
   - url: 'https://FIRECREST_URL'
 info:
-  version: 1.7.5-beta1
+  version: 1.8.0-beta1
   title: FirecREST API
   description: >
     FirecREST platform, a RESTful Services Gateway to HPC resources, is a


### PR DESCRIPTION
In this PR:
- Added optional `account` parameter to POST /compute calls
- Added `account` parameter in openapi specification
- Added more tests in compute unit tests.