### PR TITLE
Restapi 656 move base image of firecrest from centos to python

### DIFF
--- a/deploy/docker/base/Dockerfile
+++ b/deploy/docker/base/Dockerfile
@@ -4,12 +4,13 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-from centos:7 as f7t-base
+# from centos:7 as f7t-base
+FROM python:3.8.5-slim
 
 # install epel repo for python-pip package
-RUN yum install -y epel-release
-RUN yum -y update
-RUN yum install -y python3-pip
+# RUN yum install -y epel-release
+# RUN yum -y update
+# RUN yum install -y python3-pip
 
 RUN pip3 install --upgrade pip
 

--- a/deploy/docker/base/Dockerfile
+++ b/deploy/docker/base/Dockerfile
@@ -4,13 +4,7 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-# from centos:7 as f7t-base
 FROM python:3.8.5-slim
-
-# install epel repo for python-pip package
-# RUN yum install -y epel-release
-# RUN yum -y update
-# RUN yum install -y python3-pip
 
 RUN pip3 install --upgrade pip
 

--- a/deploy/docker/certificator/Dockerfile
+++ b/deploy/docker/certificator/Dockerfile
@@ -4,13 +4,21 @@
 ##  Please, refer to the LICENSE file in the root directory.
 ##  SPDX-License-Identifier: BSD-3-Clause
 ##
-ARG BASE_IMAGE=f7t-base
+ARG BASE_IMAGE=centos:7
 from $BASE_IMAGE
 
-RUN yum install -y openssh-7.4p1
+RUN yum install -y epel-release
+RUN yum -y update
+RUN yum install -y python3-pip
 
+RUN pip3 install --upgrade pip
+
+ADD deploy/docker/base/requirements.txt base/requirements.txt
 ADD deploy/docker/certificator/requirements.txt deps/requirements.txt
+RUN pip3 install -r base/requirements.txt
 RUN pip3 install -r deps/requirements.txt
+
+RUN yum install -y openssh-7.4p1
 
 ADD src/certificator/certificator.py certificator.py
 

--- a/deploy/docker/storage/requirements.txt
+++ b/deploy/docker/storage/requirements.txt
@@ -1,5 +1,5 @@
 -r ../base/requirements.txt
 keystoneauth1==4.3.0
-lxml==4.6.2
+lxml==4.6.5
 paramiko==2.6.0
 python-keystoneclient==4.2.0


### PR DESCRIPTION
FirecREST microservices base image is now `python:3:8:5-slim` (except for `certificator` that needs to install OpenSSH specific package and it's also often deployed separatelly as a service).

Also, the requirement for `lxml` library in `storage` is updated from 4.6.2 to 4.6.5 solving https://github.com/eth-cscs/firecrest/security/dependabot/deploy/docker/storage/requirements.txt/lxml/open.

