### PR TITLE
Add created_at timestamp in tasks

### DIFF
--- a/deploy/k8s/openapi/templates/cm.openapi.yaml
+++ b/deploy/k8s/openapi/templates/cm.openapi.yaml
@@ -1809,7 +1809,7 @@ items:
                     Current status of a task with `taskid`.
                     Depending on the type of task (`Compute` or `Storage`) and of the current status, the schema could change.
                     Check the field `status` to match the specific response.
-                content: 
+                content:
                   object:
                     schema:
                       oneOf:
@@ -2350,6 +2350,8 @@ items:
                 type: string
               data:
                 type: object
+              created_on:
+                type: string
               last_modify:
                 type: string
               user:
@@ -2453,6 +2455,9 @@ items:
               data:
                 type: object
                 description: Data concerning the status of the task
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2485,7 +2490,7 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
@@ -2512,6 +2517,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2544,21 +2552,21 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
                     type: object
                     description: Data concerning current operations on the task
                     properties:
-                      command: 
+                      command:
                         type: string
                         description: cURL command to execute object upload to Object Storage server
                       parameters:
                         type: object
                         description: parameters to be used with an data transfer software or library
                         properties:
-                          method: 
+                          method:
                             type: string
                             description: 'HTTP method to be used (POST, PUT). eg: with cURL `curl -X {method}`'
                           url:
@@ -2601,6 +2609,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2633,21 +2644,21 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
                     type: object
                     description: Data concerning current operations on the task
                     properties:
-                      command: 
+                      command:
                         type: string
                         description: cURL command to execute object upload to Object Storage server
                       parameters:
                         type: object
                         description: parameters to be used with an data transfer software or library
                         properties:
-                          method: 
+                          method:
                             type: string
                             description: 'HTTP method to be used (POST, PUT). eg: with cURL `curl -X {method}`'
                           url:
@@ -2690,6 +2701,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2722,7 +2736,7 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
@@ -2750,6 +2764,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2782,7 +2799,7 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
@@ -2810,6 +2827,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2842,7 +2862,7 @@ items:
                 type: object
                 description: Data concerning the status of the task
                 properties:
-                  user: 
+                  user:
                     type: string
                     description: Task owner user name
                   msg:
@@ -2870,6 +2890,9 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2902,6 +2925,9 @@ items:
                 type: string
                 description: Data concerning the status of the task
                 default: "Started upload from filesystem to Object Storage"
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2932,7 +2958,10 @@ items:
                 description: Description of the status of the task ('Upload from filesystem to Object Storage has finished succesfully')
               data:
                 type: string
-                description: Temporary URL for downloading object from Object Storage location          
+                description: Temporary URL for downloading object from Object Storage location
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2963,7 +2992,10 @@ items:
                 description: Description of the status of the task ('Upload from filesystem to Object Storage has finished with errors')
               data:
                 type: string
-                description: Error message describing the failure in the action          
+                description: Error message describing the failure in the action
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3022,7 +3054,10 @@ items:
                   job_data_err:
                     type: string
                     description: latest content of the error job file
-                    default: ""            
+                    default: ""
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3054,6 +3089,9 @@ items:
               data:
                 type: string
                 description: Description of the job submission error
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3088,13 +3126,16 @@ items:
                 default: {}
                 properties:
                   "index":
-                    type: object 
+                    type: object
                     description: index of the individual job
                     default: "0"
-                    properties: 
+                    properties:
                       schema:
                         type: object
                         $ref: "#/components/schemas/Job-Listed-Object"
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3126,6 +3167,9 @@ items:
               data:
                 type: string
                 description: Description of the job query error
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3155,9 +3199,12 @@ items:
                 type: string
                 description: Description of the status of the task ('Finished successfully')
               data:
-                type: array          
+                type: array
                 items:
                   $ref: "#/components/schemas/Job-Listed-Object"
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3189,6 +3236,9 @@ items:
               data:
                 type: string
                 description: Description of the job accounting error
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3203,7 +3253,7 @@ items:
                 description: FirecREST service that is related to the task (in this case is always `"compute"`)
               task_url:
                 type: string
-                description: URL of the task   
+                description: URL of the task
           Task-Compute-Delete-200:
             type: object
             description: Task information about success results in a task created with `DELETE /compute/jobs/{jobid}`
@@ -3218,8 +3268,11 @@ items:
                 type: string
                 description: Description of the status of the task ('Finished successfully')
               data:
-                type: string          
+                type: string
                 description: Success message of job cancelation
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3234,7 +3287,7 @@ items:
                 description: FirecREST service that is related to the task (in this case is always `"compute"`)
               task_url:
                 type: string
-                description: URL of the task 
+                description: URL of the task
           Task-Compute-Delete-400:
             type: object
             description: Task information about error results in a task created with `DELETE /compute/jobs/{jobid}`
@@ -3249,8 +3302,11 @@ items:
                 type: string
                 description: Description of the status of the task ('Finished with errors')
               data:
-                type: string          
+                type: string
                 description: Message describing job cancelation error
+              created_on:
+                type: string
+                description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3265,9 +3321,9 @@ items:
                 description: FirecREST service that is related to the task (in this case is always `"compute"`)
               task_url:
                 type: string
-                description: URL of the task 
+                description: URL of the task
           Job-Listed-Object:
-            type: object      
+            type: object
             properties:
               jobid:
                 type: string
@@ -3283,7 +3339,7 @@ items:
                 description: user name of the job owner
               state:
                 type: string
-                description: job state as described in https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES            
+                description: job state as described in https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
               start_time:
                 type: string
                 description: job actual or expected start time, as described in https://slurm.schedmd.com/squeue.html#OPT_StartTime
@@ -3318,7 +3374,7 @@ items:
               job_data_err:
                 type: string
                 description: latest content of the error job file
-                default: "" 
+                default: ""
       tags:
         - name: Status
           description: Status information of infrastructure and services.

--- a/deploy/k8s/openapi/templates/cm.openapi.yaml
+++ b/deploy/k8s/openapi/templates/cm.openapi.yaml
@@ -2352,6 +2352,8 @@ items:
                 type: object
               created_at:
                 type: string
+              updated_at:
+                type: string
               last_modify:
                 type: string
               user:
@@ -2458,6 +2460,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2520,6 +2525,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2612,6 +2620,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2704,6 +2715,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2767,6 +2781,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2830,6 +2847,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2893,6 +2913,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2928,6 +2951,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2962,6 +2988,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2996,6 +3025,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3058,6 +3090,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3092,6 +3127,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3136,6 +3174,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3170,6 +3211,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3205,6 +3249,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3239,6 +3286,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3273,6 +3323,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3307,6 +3360,9 @@ items:
               created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+              updated_at:
+                type: string
+                description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
                 type: string
                 description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)

--- a/deploy/k8s/openapi/templates/cm.openapi.yaml
+++ b/deploy/k8s/openapi/templates/cm.openapi.yaml
@@ -2350,7 +2350,7 @@ items:
                 type: string
               data:
                 type: object
-              created_on:
+              created_at:
                 type: string
               last_modify:
                 type: string
@@ -2455,7 +2455,7 @@ items:
               data:
                 type: object
                 description: Data concerning the status of the task
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2517,7 +2517,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2609,7 +2609,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2701,7 +2701,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2764,7 +2764,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2827,7 +2827,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2890,7 +2890,7 @@ items:
                   trace_id:
                     type: string
                     description: for internal use of FirecREST
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2925,7 +2925,7 @@ items:
                 type: string
                 description: Data concerning the status of the task
                 default: "Started upload from filesystem to Object Storage"
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2959,7 +2959,7 @@ items:
               data:
                 type: string
                 description: Temporary URL for downloading object from Object Storage location
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -2993,7 +2993,7 @@ items:
               data:
                 type: string
                 description: Error message describing the failure in the action
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3055,7 +3055,7 @@ items:
                     type: string
                     description: latest content of the error job file
                     default: ""
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3089,7 +3089,7 @@ items:
               data:
                 type: string
                 description: Description of the job submission error
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3133,7 +3133,7 @@ items:
                       schema:
                         type: object
                         $ref: "#/components/schemas/Job-Listed-Object"
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3167,7 +3167,7 @@ items:
               data:
                 type: string
                 description: Description of the job query error
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3202,7 +3202,7 @@ items:
                 type: array
                 items:
                   $ref: "#/components/schemas/Job-Listed-Object"
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3236,7 +3236,7 @@ items:
               data:
                 type: string
                 description: Description of the job accounting error
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3270,7 +3270,7 @@ items:
               data:
                 type: string
                 description: Success message of job cancelation
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:
@@ -3304,7 +3304,7 @@ items:
               data:
                 type: string
                 description: Message describing job cancelation error
-              created_on:
+              created_at:
                 type: string
                 description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
               last_modify:

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -2597,7 +2597,7 @@ components:
           type: string
         data:
           type: object
-        created_on:
+        created_at:
           type: string
         last_modify:
           type: string
@@ -2702,7 +2702,7 @@ components:
         data:
           type: object
           description: Data concerning the status of the task
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2764,7 +2764,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2856,7 +2856,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2948,7 +2948,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3011,7 +3011,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3074,7 +3074,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3137,7 +3137,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3172,7 +3172,7 @@ components:
           type: string
           description: Data concerning the status of the task
           default: "Started upload from filesystem to Object Storage"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3206,7 +3206,7 @@ components:
         data:
           type: string
           description: Temporary URL for downloading object from Object Storage location
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3240,7 +3240,7 @@ components:
         data:
           type: string
           description: Error message describing the failure in the action
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3302,7 +3302,7 @@ components:
               type: string
               description: latest content of the error job file
               default: ""
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3336,7 +3336,7 @@ components:
         data:
           type: string
           description: Description of the job submission error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3380,7 +3380,7 @@ components:
                 schema:
                   type: object
                   $ref: "#/components/schemas/Job-Listed-Object"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3414,7 +3414,7 @@ components:
         data:
           type: string
           description: Description of the job query error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3449,7 +3449,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Job-Listed-Object"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3483,7 +3483,7 @@ components:
         data:
           type: string
           description: Description of the job accounting error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3517,7 +3517,7 @@ components:
         data:
           type: string
           description: Success message of job cancelation
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3551,7 +3551,7 @@ components:
         data:
           type: string
           description: Message describing job cancelation error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -2597,6 +2597,8 @@ components:
           type: string
         data:
           type: object
+        created_on:
+          type: string
         last_modify:
           type: string
         user:
@@ -2700,6 +2702,9 @@ components:
         data:
           type: object
           description: Data concerning the status of the task
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2759,6 +2764,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2848,6 +2856,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2937,6 +2948,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2997,6 +3011,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3057,6 +3074,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3117,6 +3137,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3149,6 +3172,9 @@ components:
           type: string
           description: Data concerning the status of the task
           default: "Started upload from filesystem to Object Storage"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3180,6 +3206,9 @@ components:
         data:
           type: string
           description: Temporary URL for downloading object from Object Storage location
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3211,6 +3240,9 @@ components:
         data:
           type: string
           description: Error message describing the failure in the action
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3270,6 +3302,9 @@ components:
               type: string
               description: latest content of the error job file
               default: ""
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3301,6 +3336,9 @@ components:
         data:
           type: string
           description: Description of the job submission error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3342,6 +3380,9 @@ components:
                 schema:
                   type: object
                   $ref: "#/components/schemas/Job-Listed-Object"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3373,6 +3414,9 @@ components:
         data:
           type: string
           description: Description of the job query error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3405,6 +3449,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Job-Listed-Object"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3436,6 +3483,9 @@ components:
         data:
           type: string
           description: Description of the job accounting error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3467,6 +3517,9 @@ components:
         data:
           type: string
           description: Success message of job cancelation
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3498,6 +3551,9 @@ components:
         data:
           type: string
           description: Message describing job cancelation error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -2599,6 +2599,8 @@ components:
           type: object
         created_at:
           type: string
+        updated_at:
+          type: string
         last_modify:
           type: string
         user:
@@ -2705,6 +2707,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2767,6 +2772,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2859,6 +2867,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2951,6 +2962,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3014,6 +3028,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3077,6 +3094,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3140,6 +3160,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3175,6 +3198,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3209,6 +3235,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3243,6 +3272,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3305,6 +3337,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3339,6 +3374,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3383,6 +3421,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3417,6 +3458,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3452,6 +3496,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3486,6 +3533,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3520,6 +3570,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3554,6 +3607,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -2387,7 +2387,7 @@ components:
           type: string
         data:
           type: object
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2493,7 +2493,7 @@ components:
         data:
           type: object
           description: Data concerning the status of the task
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2555,7 +2555,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2647,7 +2647,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2739,7 +2739,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2802,7 +2802,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2865,7 +2865,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2928,7 +2928,7 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2963,7 +2963,7 @@ components:
           type: string
           description: Data concerning the status of the task
           default: "Started upload from filesystem to Object Storage"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -2997,7 +2997,7 @@ components:
         data:
           type: string
           description: Temporary URL for downloading object from Object Storage location
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3031,7 +3031,7 @@ components:
         data:
           type: string
           description: Error message describing the failure in the action
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3093,7 +3093,7 @@ components:
               type: string
               description: latest content of the error job file
               default: ""
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3127,7 +3127,7 @@ components:
         data:
           type: string
           description: Description of the job submission error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3171,7 +3171,7 @@ components:
                 schema:
                   type: object
                   $ref: "#/components/schemas/Job-Listed-Object"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3205,7 +3205,7 @@ components:
         data:
           type: string
           description: Description of the job query error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3240,7 +3240,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Job-Listed-Object"
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3274,7 +3274,7 @@ components:
         data:
           type: string
           description: Description of the job accounting error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3308,7 +3308,7 @@ components:
         data:
           type: string
           description: Success message of job cancelation
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
@@ -3342,7 +3342,7 @@ components:
         data:
           type: string
           description: Message describing job cancelation error
-        created_on:
+        created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -2389,7 +2389,8 @@ components:
           type: object
         created_at:
           type: string
-          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
         last_modify:
           type: string
         user:
@@ -2496,6 +2497,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2558,6 +2562,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2650,6 +2657,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2742,6 +2752,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2805,6 +2818,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2868,6 +2884,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2931,6 +2950,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2966,6 +2988,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3000,6 +3025,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3034,6 +3062,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3096,6 +3127,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3130,6 +3164,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3174,6 +3211,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3208,6 +3248,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3243,6 +3286,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3277,6 +3323,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3311,6 +3360,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3345,6 +3397,9 @@ components:
         created_at:
           type: string
           description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
+        updated_at:
+          type: string
+          description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -2387,6 +2387,9 @@ components:
           type: string
         data:
           type: object
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
         user:
@@ -2490,6 +2493,9 @@ components:
         data:
           type: object
           description: Data concerning the status of the task
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2549,6 +2555,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2638,6 +2647,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2727,6 +2739,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2787,6 +2802,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2847,6 +2865,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2907,6 +2928,9 @@ components:
             trace_id:
               type: string
               description: for internal use of FirecREST
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2939,6 +2963,9 @@ components:
           type: string
           description: Data concerning the status of the task
           default: "Started upload from filesystem to Object Storage"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -2970,6 +2997,9 @@ components:
         data:
           type: string
           description: Temporary URL for downloading object from Object Storage location
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3001,6 +3031,9 @@ components:
         data:
           type: string
           description: Error message describing the failure in the action
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3060,6 +3093,9 @@ components:
               type: string
               description: latest content of the error job file
               default: ""
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3091,6 +3127,9 @@ components:
         data:
           type: string
           description: Description of the job submission error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3132,6 +3171,9 @@ components:
                 schema:
                   type: object
                   $ref: "#/components/schemas/Job-Listed-Object"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3163,6 +3205,9 @@ components:
         data:
           type: string
           description: Description of the job query error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3195,6 +3240,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Job-Listed-Object"
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3226,6 +3274,9 @@ components:
         data:
           type: string
           description: Description of the job accounting error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3257,6 +3308,9 @@ components:
         data:
           type: string
           description: Success message of job cancelation
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)
@@ -3288,6 +3342,9 @@ components:
         data:
           type: string
           description: Message describing job cancelation error
+        created_on:
+          type: string
+          description: Date and time of the task creation (format=`%Y-%m-%dT%H:%M:%S`)
         last_modify:
           type: string
           description: Date and time of latest update of the task (format=`%Y-%m-%dT%H:%M:%S`)

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -6,7 +6,6 @@
 #
 from hashlib import md5
 import time
-import json
 import logging
 import copy
 
@@ -72,7 +71,8 @@ class AsyncTask():
         self.data = {}
         self.user = user
         self.service = service
-        self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.created_on = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.timestamp = self.created_on
 
     # create hash_id as user-task_id MD5 encoded string
     # used for public access to info in Queue
@@ -101,27 +101,27 @@ class AsyncTask():
     # return status for internal info (returns SSH "cert"ificate or "action")
     def get_internal_status(self):
 
-        return {"task_id":self.hash_id,
-                "hash_id":self.hash_id,
+        return {"task_id": self.hash_id,
+                "hash_id": self.hash_id,
                 "user": self.user,
-                "status":self.status_code,
-                "description":self.status_desc,                
+                "status": self.status_code,
+                "description": self.status_desc,
                 "data": self.data,
-                "service":self.service,
-                "last_modify":self.timestamp}
+                "service": self.service,
+                "created_on": self.created_on,
+                "last_modify": self.timestamp}
 
     # return status for public info, so task_id is discarded
     def get_status(self):
 
         # hide users certificate and action details
         # ["msg"]["certs"] & ["msg"]["action"]
-        
-                
+
         # if dict, then a deepcopy is needed, otherwise the dict in "msg" will be shallow copied
         if isinstance(self.data, dict):
-        
+
             _data = copy.deepcopy(self.data)
-        
+
             if len(_data) != 0:
 
                 try:
@@ -137,11 +137,13 @@ class AsyncTask():
             _data = self.data
 
         return {
-                "task_id": self.hash_id,
-                "hash_id":self.hash_id,
-                "user": self.user,
-                "status":self.status_code,
-                "description":self.status_desc,                
-                "data": _data,
-                "service":self.service,
-                "last_modify":self.timestamp}
+            "task_id": self.hash_id,
+            "hash_id": self.hash_id,
+            "user": self.user,
+            "status": self.status_code,
+            "description": self.status_desc,
+            "data": _data,
+            "service": self.service,
+            "created_on": self.created_on,
+            "last_modify": self.timestamp
+        }

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -72,7 +72,7 @@ class AsyncTask():
         self.user = user
         self.service = service
         self.created_at = time.strftime("%Y-%m-%dT%H:%M:%S")
-        self.timestamp = self.created_at
+        self.updated_at = self.created_at
 
     # create hash_id as user-task_id MD5 encoded string
     # used for public access to info in Queue
@@ -94,9 +94,9 @@ class AsyncTask():
         self.status_code = status
         self.status_desc = status_codes[str(status)]
         if data != None:
-            # self.data = json.dumps(data)
             self.data = data
-        self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+        self.updated_at = time.strftime("%Y-%m-%dT%H:%M:%S")
 
     # return status for internal info (returns SSH "certificate" or "action")
     def get_internal_status(self):
@@ -109,7 +109,8 @@ class AsyncTask():
                 "data": self.data,
                 "service": self.service,
                 "created_at": self.created_at,
-                "last_modify": self.timestamp}
+                "updated_at": self.updated_at,
+                "last_modify": self.updated_at}
 
     # return status for public info, so task_id is discarded
     def get_status(self):
@@ -144,4 +145,5 @@ class AsyncTask():
                 "data": _data,
                 "service": self.service,
                 "created_at": self.created_at,
-                "last_modify": self.timestamp}
+                "updated_at": self.updated_at,
+                "last_modify": self.updated_at}

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -98,7 +98,7 @@ class AsyncTask():
             self.data = data
         self.timestamp = time.strftime("%Y-%m-%dT%H:%M:%S")
 
-    # return status for internal info (returns SSH "cert"ificate or "action")
+    # return status for internal info (returns SSH "certificate" or "action")
     def get_internal_status(self):
 
         return {"task_id": self.hash_id,
@@ -136,14 +136,12 @@ class AsyncTask():
         else:
             _data = self.data
 
-        return {
-            "task_id": self.hash_id,
-            "hash_id": self.hash_id,
-            "user": self.user,
-            "status": self.status_code,
-            "description": self.status_desc,
-            "data": _data,
-            "service": self.service,
-            "created_on": self.created_on,
-            "last_modify": self.timestamp
-        }
+        return {"task_id": self.hash_id,
+                "hash_id": self.hash_id,
+                "user": self.user,
+                "status": self.status_code,
+                "description": self.status_desc,
+                "data": _data,
+                "service": self.service,
+                "created_on": self.created_on,
+                "last_modify": self.timestamp}

--- a/src/common/async_task.py
+++ b/src/common/async_task.py
@@ -71,8 +71,8 @@ class AsyncTask():
         self.data = {}
         self.user = user
         self.service = service
-        self.created_on = time.strftime("%Y-%m-%dT%H:%M:%S")
-        self.timestamp = self.created_on
+        self.created_at = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.timestamp = self.created_at
 
     # create hash_id as user-task_id MD5 encoded string
     # used for public access to info in Queue
@@ -108,7 +108,7 @@ class AsyncTask():
                 "description": self.status_desc,
                 "data": self.data,
                 "service": self.service,
-                "created_on": self.created_on,
+                "created_at": self.created_at,
                 "last_modify": self.timestamp}
 
     # return status for public info, so task_id is discarded
@@ -143,5 +143,5 @@ class AsyncTask():
                 "description": self.status_desc,
                 "data": _data,
                 "service": self.service,
-                "created_on": self.created_on,
+                "created_at": self.created_at,
                 "last_modify": self.timestamp}


### PR DESCRIPTION
I wasn't sure about the name of this new field. Most of the fields of the task are nouns: `status`, `user` etc. The only other verb is in `last_modify` and I don't like too much the present form. I would rename `last_modify` to `updated_on` to be consistent but maybe somebody is using it. Do you have any better suggestion instead of `created_on`?