### PR TITLE
Restapi 685 Fix responses in openapi docs

### DIFF
--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -609,6 +609,74 @@ paths:
             text/plain:
               schema:
                 type: string
+  '/utilities/stat':
+    parameters:
+      - in: header
+        name: X-Machine-Name
+        description: The system name
+        required: true
+        schema:
+          type: string
+    get:
+      summary: determines the status of a file
+      description: Uses the stat linux application to determine the status of a file on the
+        {X-Machine-Name} filesystem.
+      tags:
+        - Utilities
+      parameters:
+        - name: targetPath
+          in: query
+          description: Absolute filesystem path
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
+          allowReserved: true
+        - name: dereference
+          in: query
+          description: Follow symbolic links
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Operation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
+        '400':
+          description: Error in file operation
+          content:
+            text/plain:
+              schema:
+                type: string
+          headers:
+            X-Machine-Does-Not-Exist:
+              description: Machine does not exist
+              schema:
+                type: string
+            X-Machine-Not-Available:
+              description: Machine is not available
+              schema:
+                type: string
+            X-Permission-Denied:
+              description: User does not have permissions to access machine or paths
+              schema:
+                type: string
+            X-Invalid-Path:
+              description: <path> is an invalid path
+              schema:
+                type: string
+            X-Timeout:
+              description: Command has finished with timeout signal
+              schema:
+                type: string
+        '401':
+          description: No auth header given
+          content:
+            text/plain:
+              schema:
+                type: string
   '/utilities/symlink':
     parameters:
       - in: header

--- a/doc/openapi/firecrest-api.yaml
+++ b/doc/openapi/firecrest-api.yaml
@@ -211,6 +211,10 @@ paths:
       responses:
         '201':
           description: Directory created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error creating directory
           content:
@@ -279,6 +283,10 @@ paths:
       responses:
         '200':
           description: Success to rename file or directory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error on rename operation
           content:
@@ -352,7 +360,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in chmod operation
           content:
@@ -427,7 +435,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in chwon operation
           content:
@@ -502,7 +510,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in copy operation
           content:
@@ -567,7 +575,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in file operation
           content:
@@ -638,6 +646,10 @@ paths:
       responses:
         '201':
           description: Success create the symlink
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to create symlink
           content:
@@ -759,6 +771,10 @@ paths:
       responses:
         '201':
           description: File upload successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to upload file
           content:
@@ -812,6 +828,10 @@ paths:
       responses:
         '204':
           description: File deletion successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to delete file
           content:
@@ -2432,9 +2452,16 @@ components:
         size:
           type: string
     Files-metadata:
-      type: array
-      items:
-        $ref: '#/components/schemas/File-metadata'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - "List of contents"
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/File-metadata'
     System:
       required:
         - system
@@ -2449,21 +2476,44 @@ components:
         description:
           type: string
     Systems:
-      type: array
-      items:
-        $ref: '#/components/schemas/System'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - "List of systems with status and description."
+        out:
+          type: array
+          items:
+            $ref: '#/components/schemas/System'
     Parameters:
       type: object
       properties:
-        microservice-name:
+        description:
+          type: string
+          enum:
+            - "Firecrest's parameters"
+        out:
           type: object
           properties:
-            name:
-              type: string
-            value:
-              type: string
-            unit:
-              type: string
+            storage:
+              type: object
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+                unit:
+                  type: string
+            utilities:
+              type: object
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+                unit:
+                  type: string
     Error:
       properties:
         code:
@@ -2484,9 +2534,16 @@ components:
         description:
           type: string
     Services:
-      type: array
-      items:
-        $ref: '#/components/schemas/Service'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - 'List of services with status and description.'
+        out:
+          type: array
+          items:
+            $ref: '#/components/schemas/Service'
     Job:
       type: object
       required:
@@ -2577,15 +2634,6 @@ components:
           type: string
         session_id:
           type: string
-    Application-output:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: Standard output returned by application
-        stderr:
-          type: string
-          description: Standard error returned by application.
     Task:
       type: object
       properties:

--- a/doc/openapi/firecrest-developers-api.yaml
+++ b/doc/openapi/firecrest-developers-api.yaml
@@ -220,6 +220,10 @@ paths:
       responses:
         '201':
           description: Directory created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error creating directory
           content:
@@ -288,6 +292,10 @@ paths:
       responses:
         '200':
           description: Success to rename file or directory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error on rename operation
           content:
@@ -361,7 +369,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in chmod operation
           content:
@@ -436,7 +444,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in chwon operation
           content:
@@ -511,7 +519,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in copy operation
           content:
@@ -576,7 +584,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in file operation
           content:
@@ -644,7 +652,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Application-output'
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Error in file operation
           content:
@@ -715,6 +723,10 @@ paths:
       responses:
         '201':
           description: Success create the symlink
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to create symlink
           content:
@@ -836,6 +848,10 @@ paths:
       responses:
         '201':
           description: File upload successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to upload file
           content:
@@ -889,6 +905,10 @@ paths:
       responses:
         '204':
           description: File deletion successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Utilities-ok'
         '400':
           description: Failed to delete file
           content:
@@ -2339,9 +2359,16 @@ components:
         size:
           type: string
     Files-metadata:
-      type: array
-      items:
-        $ref: '#/components/schemas/File-metadata'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - "List of contents"
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/File-metadata'
     System:
       required:
         - system
@@ -2356,21 +2383,44 @@ components:
         description:
           type: string
     Systems:
-      type: array
-      items:
-        $ref: '#/components/schemas/System'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - "List of systems with status and description."
+        out:
+          type: array
+          items:
+            $ref: '#/components/schemas/System'
     Parameters:
       type: object
       properties:
-        microservice-name:
+        description:
+          type: string
+          enum:
+            - "Firecrest's parameters"
+        out:
           type: object
           properties:
-            name:
-              type: string
-            value:
-              type: string
-            unit:
-              type: string
+            storage:
+              type: object
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+                unit:
+                  type: string
+            utilities:
+              type: object
+              properties:
+                name:
+                  type: string
+                value:
+                  type: string
+                unit:
+                  type: string
     Error:
       properties:
         code:
@@ -2391,9 +2441,16 @@ components:
         description:
           type: string
     Services:
-      type: array
-      items:
-        $ref: '#/components/schemas/Service'
+      type: object
+      properties:
+        description:
+          type: string
+          enum:
+            - 'List of services with status and description.'
+        out:
+          type: array
+          items:
+            $ref: '#/components/schemas/Service'
     Job:
       type: object
       required:
@@ -2435,15 +2492,6 @@ components:
           type: string
         session_id:
           type: string
-    Application-output:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: Standard output returned by application
-        stderr:
-          type: string
-          description: Standard error returned by application.
     Task:
       type: object
       properties:


### PR DESCRIPTION
This PR fixes the following issues:
- Fix the output schema for some of the utilities calls. It was:
```json
{
  "stdout": "string",
  "stderr": "string"
}
```

- Fix the `/utilities/systems` and `/utilities/services` schema

- Add `/utilties/stat` in  `doc/openapi/firecrest-api.yaml`