### PR TITLE
bump slurm version of dummy build

### DIFF
--- a/deploy/test-build/cluster/Dockerfile
+++ b/deploy/test-build/cluster/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM centos:7
 
-ARG SLURM_VERSION=20.11.7
+ARG SLURM_VERSION=20.11.9
 
 RUN set -ex \
     && yum makecache fast \


### PR DESCRIPTION
`20.11.7` does not exist in https://download.schedmd.com/slurm/ anymore.